### PR TITLE
feat(core): validateAll() — validate all steps (WIZ-008)

### DIFF
--- a/.changeset/wiz-008-validate-all.md
+++ b/.changeset/wiz-008-validate-all.md
@@ -1,0 +1,26 @@
+---
+"@gooonzick/wizard-core": minor
+"@gooonzick/wizard-react": minor
+"@gooonzick/wizard-vue": minor
+"@gooonzick/wizard-state": minor
+---
+
+feat: add validateAll for validating every step at once (WIZ-008)
+
+Add `WizardMachine.validateAll(options?)` which runs the validator of every
+**enabled** step and returns a structured `ValidationSummary` (per-step results
+plus `valid`, `firstInvalidStepId`, and `invalidStepIds` in definition order).
+Useful on a final "Review/Summary" step to show which earlier steps still have
+errors and to jump straight to the first invalid one.
+
+- Dry-run by default: it does NOT mutate `stepStatuses`, `isValid`, or
+  `validationErrors`, fires no `onValidation`/`onStateChange`, and is fully
+  isolated from the plugin system (a thrown validator is caught and reported as
+  `{ _error: <message> }` on that step, without dispatching `onError`).
+- Steps without a validator count as valid; disabled steps (static `false` or a
+  guard resolving to false) are skipped entirely.
+- With `updateStatuses: true`, invalid steps are marked `"error"` in a single
+  state write that emits exactly one `onStateChange`.
+- Exposed on the `actions` slice of the React and Vue hooks
+  (`actions.validateAll(...)`); toggles `isValidating` for the duration.
+- New exported types: `ValidationSummary` and `StepValidationSummary`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -34,6 +34,7 @@
 | Reset / Cancel (WIZ-005)                              | ✅     | `core`  |
 | State Persistence (WIZ-006)                           | ✅     | `core`  |
 | Plugin System (WIZ-007)                               | ✅     | `core`  |
+| Validate All Steps (WIZ-008)                          | ✅     | `core`  |
 
 ### Architectural Decisions
 
@@ -641,8 +642,8 @@ class WizardMachine<TData> {
 }
 
 // React
-const { validation } = useWizard({ ... });
-const summary = await validation.validateAll();
+const { actions, navigation } = useWizard({ ... });
+const summary = await actions.validateAll();
 if (!summary.valid) {
   navigation.goTo(summary.firstInvalidStepId!, { skipValidation: true });
 }

--- a/examples/react-examples/src/wizard-example.tsx
+++ b/examples/react-examples/src/wizard-example.tsx
@@ -1,5 +1,5 @@
-import { createWizard } from "@gooonzick/wizard-core";
 import type { ValidationSummary } from "@gooonzick/wizard-core";
+import { createWizard } from "@gooonzick/wizard-core";
 import { useWizard } from "@gooonzick/wizard-react";
 import type React from "react";
 import { useState } from "react";

--- a/examples/react-examples/src/wizard-example.tsx
+++ b/examples/react-examples/src/wizard-example.tsx
@@ -1,6 +1,8 @@
 import { createWizard } from "@gooonzick/wizard-core";
+import type { ValidationSummary } from "@gooonzick/wizard-core";
 import { useWizard } from "@gooonzick/wizard-react";
 import type React from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { WizardForm } from "./components/wizard-form";
 import { WizardProgress } from "./components/wizard-progress";
@@ -74,6 +76,17 @@ export const WizardExample: React.FC = () => {
 		review: "Review",
 	};
 
+	// Review-step demo: validate every step at once and jump to the first invalid.
+	const [allSummary, setAllSummary] = useState<ValidationSummary | null>(null);
+
+	const handleValidateAll = async () => {
+		const summary = await actions.validateAll({ updateStatuses: true });
+		setAllSummary(summary);
+		if (!summary.valid && summary.firstInvalidStepId) {
+			navigation.goTo(summary.firstInvalidStepId, { skipValidation: true });
+		}
+	};
+
 	return (
 		<div className="min-h-screen bg-gray-50 py-8 px-4">
 			<div className="max-w-7xl mx-auto">
@@ -124,14 +137,25 @@ export const WizardExample: React.FC = () => {
 									Next
 								</Button>
 							) : (
-								<Button
-									onClick={() => actions.submit()}
-									className="bg-green-600 hover:bg-green-700"
-								>
-									Submit
-								</Button>
+								<>
+									<Button variant="outline" onClick={handleValidateAll}>
+										Validate all
+									</Button>
+									<Button
+										onClick={() => actions.submit()}
+										className="bg-green-600 hover:bg-green-700"
+									>
+										Submit
+									</Button>
+								</>
 							)}
 						</div>
+
+						{allSummary && !allSummary.valid && (
+							<p className="text-sm text-red-600 mt-2">
+								Invalid steps: {allSummary.invalidStepIds.join(", ")}
+							</p>
+						)}
 					</div>
 
 					{/* Sidebar */}

--- a/examples/vue-examples/src/wizard-example/use-wizard-example.vue
+++ b/examples/vue-examples/src/wizard-example/use-wizard-example.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import type { ValidationSummary } from "@gooonzick/wizard-core";
 import { useWizard } from "@gooonzick/wizard-vue";
+import { ref } from "vue";
 import Button from "@/components/ui/button.vue";
 import Card from "@/components/ui/card.vue";
 import WizardForm from "@/components/wizard-form.vue";
@@ -17,6 +19,16 @@ const { navigation, actions, state, validation } = useWizard({
 		alert("Wizard completed! Check console for data.");
 	},
 });
+
+// Review-step demo: validate every step at once and jump to the first invalid.
+const allSummary = ref<ValidationSummary | null>(null);
+const handleValidateAll = async () => {
+	const summary = await actions.validateAll({ updateStatuses: true });
+	allSummary.value = summary;
+	if (!summary.valid && summary.firstInvalidStepId) {
+		navigation.goTo(summary.firstInvalidStepId, { skipValidation: true });
+	}
+};
 </script>
 
 <template>
@@ -67,6 +79,9 @@ const { navigation, actions, state, validation } = useWizard({
 							</Button>
 						</template>
 						<template v-else>
+							<Button variant="outline" @click="handleValidateAll">
+								Validate all
+							</Button>
 							<Button
 								@click="actions.submit"
 								class="bg-green-600 hover:bg-green-700"
@@ -75,6 +90,13 @@ const { navigation, actions, state, validation } = useWizard({
 							</Button>
 						</template>
 					</div>
+
+					<p
+						v-if="allSummary && !allSummary.valid"
+						class="text-sm text-red-600 mt-2"
+					>
+						Invalid steps: {{ allSummary.invalidStepIds.join(", ") }}
+					</p>
 				</Card>
 
 				<!-- Right Column - Sidebar -->

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,8 +54,10 @@ export type {
 } from "./plugins/types";
 export type {
 	StepId,
+	StepValidationSummary,
 	SyncOrAsync,
 	ValidationResult,
+	ValidationSummary,
 	WizardContext,
 	WizardData,
 } from "./types/base";

--- a/packages/core/src/machine/wizard-machine.ts
+++ b/packages/core/src/machine/wizard-machine.ts
@@ -478,9 +478,9 @@ export class WizardMachine<T extends WizardData> {
 	 * `updateStatuses: true`, invalid steps are marked "error" in a single state
 	 * write that emits exactly one onStateChange.
 	 */
-	async validateAll(
-		options?: { updateStatuses?: boolean },
-	): Promise<ValidationSummary> {
+	async validateAll(options?: {
+		updateStatuses?: boolean;
+	}): Promise<ValidationSummary> {
 		this.checkAborted();
 		const { updateStatuses = false } = options ?? {};
 

--- a/packages/core/src/machine/wizard-machine.ts
+++ b/packages/core/src/machine/wizard-machine.ts
@@ -14,7 +14,9 @@ import type {
 } from "../plugins/types";
 import type {
 	StepId,
+	StepValidationSummary,
 	ValidationResult,
+	ValidationSummary,
 	WizardContext,
 	WizardData,
 } from "../types/base";
@@ -463,6 +465,75 @@ export class WizardMachine<T extends WizardData> {
 			this.validateAlreadyReported = true;
 			return { valid: false, errors: { general: "Validation error occurred" } };
 		}
+	}
+
+	/**
+	 * Validates every ENABLED step's validator without navigating (dry-run).
+	 * Steps without a `validate` are considered valid. Steps whose `enabled`
+	 * guard resolves to false are skipped entirely (not included in the summary).
+	 *
+	 * By default this does NOT mutate stepStatuses, isValid, or validationErrors,
+	 * does NOT fire onValidation/onStateChange, and is FULLY ISOLATED from plugins
+	 * (no plugin hook — including onError — is dispatched). With
+	 * `updateStatuses: true`, invalid steps are marked "error" in a single state
+	 * write that emits exactly one onStateChange.
+	 */
+	async validateAll(
+		options?: { updateStatuses?: boolean },
+	): Promise<ValidationSummary> {
+		this.checkAborted();
+		const { updateStatuses = false } = options ?? {};
+
+		const steps: StepValidationSummary[] = [];
+		const invalidStepIds: StepId[] = [];
+
+		// Insertion order == canonical order (matches computeProgress / Progress API).
+		for (const [stepId, step] of Object.entries(this.definition.steps)) {
+			// Skip disabled steps (boolean false OR guard resolving to false).
+			const isEnabled = await evaluateGuard(
+				step.enabled,
+				this.state.data,
+				this.context,
+			);
+			if (!isEnabled) {
+				continue;
+			}
+
+			const validator = step.validate || alwaysValid;
+
+			let result: ValidationResult;
+			try {
+				result = await validator(this.state.data, this.context);
+			} catch (error) {
+				// A thrown validator is caught here and marked invalid with the
+				// sentinel `_error` field. Do NOT call handleError / dispatch to
+				// plugins — validateAll is fully isolated from the plugin system.
+				const message = error instanceof Error ? error.message : String(error);
+				result = { valid: false, errors: { _error: message } };
+			}
+
+			steps.push({ stepId, valid: result.valid, errors: result.errors });
+			if (!result.valid) {
+				invalidStepIds.push(stepId);
+			}
+		}
+
+		// Optionally persist "error" on invalid steps in a SINGLE state write.
+		if (updateStatuses && invalidStepIds.length > 0) {
+			const nextStatuses = { ...this.state.stepStatuses };
+			for (const id of invalidStepIds) {
+				nextStatuses[id] = "error";
+			}
+			this.state = { ...this.state, stepStatuses: nextStatuses };
+			this.notifyStateChange(); // exactly one emit
+		}
+
+		return {
+			valid: invalidStepIds.length === 0,
+			steps,
+			firstInvalidStepId: invalidStepIds[0] ?? null,
+			invalidStepIds,
+		};
 	}
 
 	/**

--- a/packages/core/src/types/base.ts
+++ b/packages/core/src/types/base.ts
@@ -12,6 +12,26 @@ export type ValidationResult = {
 };
 
 /**
+ * Per-step entry inside a {@link ValidationSummary}.
+ */
+export interface StepValidationSummary {
+	stepId: StepId;
+	valid: boolean;
+	errors?: Record<string, string>;
+}
+
+/**
+ * Aggregate result of validating every enabled step (returned by
+ * `WizardMachine.validateAll`).
+ */
+export interface ValidationSummary {
+	valid: boolean;
+	steps: StepValidationSummary[];
+	firstInvalidStepId: StepId | null;
+	invalidStepIds: StepId[];
+}
+
+/**
  * Base constraint for wizard data types.
  * Any object type with string keys is allowed - no need to extend Record<string, unknown>.
  *

--- a/packages/core/tests/validate-all.test.ts
+++ b/packages/core/tests/validate-all.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	type WizardEvents,
+	WizardMachine,
+} from "../src/machine/wizard-machine";
+import type { WizardDefinition } from "../src/types/definition";
+import type { WizardPlugin } from "../src/plugins/types";
+import {
+	createConditionalDefinition,
+	createValidatedDefinition,
+	type FormData,
+	type SimpleData,
+} from "./fixtures";
+
+const defaultContext = {};
+
+function createValidatedMachine(
+	overrides: Partial<SimpleData> = {},
+	events?: WizardEvents<SimpleData>,
+): WizardMachine<SimpleData> {
+	const initialData: SimpleData = {
+		name: "Ada",
+		email: "ada@example.com",
+		...overrides,
+	};
+	return new WizardMachine(
+		createValidatedDefinition(),
+		defaultContext,
+		initialData,
+		events,
+	);
+}
+
+function createConditionalMachine(
+	overrides: Partial<FormData> = {},
+	events?: WizardEvents<FormData>,
+): WizardMachine<FormData> {
+	const initialData: FormData = {
+		name: "Ada",
+		email: "ada@example.com",
+		age: 30,
+		enabled: false,
+		...overrides,
+	};
+	return new WizardMachine(
+		createConditionalDefinition(),
+		defaultContext,
+		initialData,
+		events,
+	);
+}
+
+describe("WizardMachine.validateAll", () => {
+	it("reports all steps valid with no invalid ids (case 1)", async () => {
+		const machine = createValidatedMachine();
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(true);
+		expect(summary.invalidStepIds).toEqual([]);
+		expect(summary.firstInvalidStepId).toBeNull();
+		// step1, step2, step3 all enabled.
+		expect(summary.steps.map((s) => s.stepId)).toEqual([
+			"step1",
+			"step2",
+			"step3",
+		]);
+	});
+
+	it("flags a single invalid step (case 2)", async () => {
+		const machine = createValidatedMachine({ name: "" });
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(false);
+		expect(summary.firstInvalidStepId).toBe("step1");
+		expect(summary.invalidStepIds).toEqual(["step1"]);
+		const step1 = summary.steps.find((s) => s.stepId === "step1");
+		expect(step1?.errors).toEqual({ name: "Name is required" });
+	});
+
+	it("lists multiple invalid steps in definition order (case 3)", async () => {
+		const machine = createValidatedMachine({ name: "", email: "" });
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(false);
+		expect(summary.invalidStepIds).toEqual(["step1", "step2"]);
+		expect(summary.firstInvalidStepId).toBe("step1");
+	});
+
+	it("skips a disabled step (case 4)", async () => {
+		// `optional` has enabled guard (d) => d.enabled; enabled:false skips it.
+		const machine = createConditionalMachine({ enabled: false });
+
+		const summary = await machine.validateAll();
+
+		const stepIds = summary.steps.map((s) => s.stepId);
+		expect(stepIds).not.toContain("optional");
+		expect(stepIds).toEqual(["personal", "preferences", "summary"]);
+	});
+
+	it("treats a step without validate as valid and includes it (case 5)", async () => {
+		const machine = createValidatedMachine();
+
+		const summary = await machine.validateAll();
+
+		const step3 = summary.steps.find((s) => s.stepId === "step3");
+		expect(step3).toBeDefined();
+		expect(step3?.valid).toBe(true);
+		expect(step3?.errors).toBeUndefined();
+	});
+
+	it("awaits async validators (case 6)", async () => {
+		// createValidatedDefinition uses async validators; assert the resolved
+		// values are reflected (not left as pending promises).
+		const machine = createValidatedMachine({ name: "Grace", email: "" });
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(false);
+		expect(summary.invalidStepIds).toEqual(["step2"]);
+		const step1 = summary.steps.find((s) => s.stepId === "step1");
+		expect(step1?.valid).toBe(true);
+	});
+
+	it("updateStatuses:true marks invalid steps error and emits once (case 7)", async () => {
+		const onStateChange = vi.fn();
+		const machine = createValidatedMachine(
+			{ name: "", email: "" },
+			{ onStateChange },
+		);
+		// Ignore the initial construction emit; count only validateAll's.
+		onStateChange.mockClear();
+
+		const summary = await machine.validateAll({ updateStatuses: true });
+
+		expect(summary.valid).toBe(false);
+		expect(machine.getStepStatus("step1")).toBe("error");
+		expect(machine.getStepStatus("step2")).toBe("error");
+		expect(onStateChange).toHaveBeenCalledTimes(1);
+	});
+
+	it("default (dry-run) does not mutate stepStatuses or emit (case 8)", async () => {
+		const onStateChange = vi.fn();
+		const machine = createValidatedMachine(
+			{ name: "", email: "" },
+			{ onStateChange },
+		);
+		const step1StatusBefore = machine.getStepStatus("step1");
+		// Ignore the initial construction emit; validateAll must not emit.
+		onStateChange.mockClear();
+
+		await machine.validateAll();
+
+		expect(machine.getStepStatus("step1")).toBe(step1StatusBefore);
+		expect(onStateChange).not.toHaveBeenCalled();
+	});
+
+	it("dry-run does not alter live isValid / validationErrors (case 9)", async () => {
+		const machine = createValidatedMachine({ name: "", email: "" });
+		const isValidBefore = machine.snapshot.isValid;
+		const errorsBefore = machine.snapshot.validationErrors;
+
+		await machine.validateAll();
+
+		expect(machine.snapshot.isValid).toBe(isValidBefore);
+		expect(machine.snapshot.validationErrors).toEqual(errorsBefore);
+	});
+
+	it("catches a thrown validator without plugin/event onError (case 10)", async () => {
+		const onError = vi.fn();
+		const pluginOnError = vi.fn();
+		const plugin: WizardPlugin<Record<string, unknown>> = {
+			name: "spy",
+			onError: pluginOnError,
+		};
+		const definition: WizardDefinition<Record<string, unknown>> = {
+			id: "throwing",
+			initialStepId: "boom",
+			steps: {
+				boom: {
+					id: "boom",
+					validate: () => {
+						throw new Error("kaboom");
+					},
+				},
+			},
+		};
+		const machine = new WizardMachine(
+			definition,
+			defaultContext,
+			{},
+			{ onError },
+			[plugin],
+		);
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(false);
+		expect(summary.invalidStepIds).toEqual(["boom"]);
+		const boom = summary.steps.find((s) => s.stepId === "boom");
+		expect(boom?.errors).toEqual({ _error: "kaboom" });
+		expect(onError).not.toHaveBeenCalled();
+		expect(pluginOnError).not.toHaveBeenCalled();
+	});
+
+	it("returns an empty summary when all steps are disabled (case 11)", async () => {
+		const definition: WizardDefinition<Record<string, unknown>> = {
+			id: "all-disabled",
+			initialStepId: "a",
+			steps: {
+				a: { id: "a", enabled: false },
+				b: { id: "b", enabled: false },
+			},
+		};
+		const machine = new WizardMachine(definition, defaultContext, {});
+
+		const summary = await machine.validateAll();
+
+		expect(summary.steps).toEqual([]);
+		expect(summary.valid).toBe(true);
+		expect(summary.firstInvalidStepId).toBeNull();
+		expect(summary.invalidStepIds).toEqual([]);
+	});
+
+	it("updateStatuses:true with all valid does not emit or set error (case 12)", async () => {
+		const onStateChange = vi.fn();
+		const machine = createValidatedMachine({}, { onStateChange });
+		// Ignore the initial construction emit; validateAll must not emit.
+		onStateChange.mockClear();
+
+		const summary = await machine.validateAll({ updateStatuses: true });
+
+		expect(summary.valid).toBe(true);
+		expect(onStateChange).not.toHaveBeenCalled();
+		expect(machine.getStepStatus("step1")).not.toBe("error");
+	});
+
+	it("respects a function-guard enabled step when data flips (case 13)", async () => {
+		const machine = createConditionalMachine({ enabled: true });
+
+		const summary = await machine.validateAll();
+
+		const stepIds = summary.steps.map((s) => s.stepId);
+		expect(stepIds).toContain("optional");
+	});
+
+	it("runs after the wizard is completed (case 14)", async () => {
+		const definition: WizardDefinition<Record<string, unknown>> = {
+			id: "single",
+			initialStepId: "only",
+			steps: {
+				only: { id: "only" },
+			},
+		};
+		const machine = new WizardMachine(definition, defaultContext, {});
+		await machine.submit();
+		expect(machine.snapshot.isCompleted).toBe(true);
+
+		const summary = await machine.validateAll();
+
+		expect(summary.valid).toBe(true);
+		expect(summary.steps.map((s) => s.stepId)).toEqual(["only"]);
+	});
+});

--- a/packages/core/tests/validate-all.test.ts
+++ b/packages/core/tests/validate-all.test.ts
@@ -3,8 +3,8 @@ import {
 	type WizardEvents,
 	WizardMachine,
 } from "../src/machine/wizard-machine";
-import type { WizardDefinition } from "../src/types/definition";
 import type { WizardPlugin } from "../src/plugins/types";
+import type { WizardDefinition } from "../src/types/definition";
 import {
 	createConditionalDefinition,
 	createValidatedDefinition,

--- a/packages/docs/guide/api/core.md
+++ b/packages/docs/guide/api/core.md
@@ -134,6 +134,31 @@ interface ValidationResult {
 }
 ```
 
+### `ValidationSummary`
+
+Aggregate result of validating every enabled step (returned by `validateAll`).
+
+```ts
+interface ValidationSummary {
+  valid: boolean;                    // true iff all validated steps are valid
+  steps: StepValidationSummary[];    // one entry per validated (enabled) step
+  firstInvalidStepId: StepId | null; // first invalid step in definition order
+  invalidStepIds: StepId[];          // all invalid step ids, in definition order
+}
+```
+
+### `StepValidationSummary`
+
+Per-step entry inside a `ValidationSummary`.
+
+```ts
+interface StepValidationSummary {
+  stepId: StepId;
+  valid: boolean;
+  errors?: Record<string, string>;
+}
+```
+
 ### `WizardContext`
 
 Context passed to validators, hooks, and transitions. Extensible.
@@ -414,6 +439,8 @@ class WizardMachine<T> {
 
   // Validation & submission
   validate(): Promise<void>;
+  // Validate ALL enabled steps without navigating (dry-run).
+  validateAll(options?: { updateStatuses?: boolean }): Promise<ValidationSummary>;
   canSubmit(): Promise<boolean>;
   submit(): Promise<void>;
 

--- a/packages/docs/guide/api/react.md
+++ b/packages/docs/guide/api/react.md
@@ -86,6 +86,7 @@ interface UseWizardActions<T> {
   setData(data: T): void;
   updateField<K extends keyof T>(field: K, value: T[K]): void;
   validate(): Promise<void>;
+  validateAll(options?: { updateStatuses?: boolean }): Promise<ValidationSummary>;
   canSubmit(): Promise<boolean>;
   submit(): Promise<void>;
   reset(data?: T): void;

--- a/packages/docs/guide/api/vue.md
+++ b/packages/docs/guide/api/vue.md
@@ -86,6 +86,7 @@ interface UseWizardActions<T> {
   setData(data: T): void;
   updateField<K extends keyof T>(field: K, value: T[K]): void;
   validate(): Promise<void>;
+  validateAll(options?: { updateStatuses?: boolean }): Promise<ValidationSummary>;
   canSubmit(): Promise<boolean>;
   submit(): Promise<void>;
   reset(data?: T): void;

--- a/packages/docs/guide/core-concepts.md
+++ b/packages/docs/guide/core-concepts.md
@@ -206,6 +206,32 @@ validate: async (data, ctx) => {
 };
 ```
 
+### Validating All Steps
+
+`validate()` only checks the current step. To check every enabled step at once —
+useful on a final "Review/Summary" step — call `validateAll()`. It runs each
+enabled step's validator, skips disabled steps and steps without a validator
+(treated as valid), and returns a `ValidationSummary` without mutating live
+validation state (it is a dry-run by default):
+
+```ts
+const summary = await machine.validateAll();
+// summary.valid, summary.invalidStepIds, summary.firstInvalidStepId, summary.steps
+
+// Optionally mark invalid steps with the "error" status:
+await machine.validateAll({ updateStatuses: true });
+```
+
+In React/Vue, `validateAll` lives on the `actions` slice:
+
+```ts
+const { actions, navigation } = useWizard({ ... });
+const summary = await actions.validateAll();
+if (!summary.valid) {
+  navigation.goTo(summary.firstInvalidStepId!, { skipValidation: true });
+}
+```
+
 ## 6. Guards
 
 Guards control **whether a step is accessible**. Use them for conditional logic about step availability:

--- a/packages/react/src/use-wizard-granular.tsx
+++ b/packages/react/src/use-wizard-granular.tsx
@@ -268,6 +268,18 @@ export function useWizardActions<T extends WizardData>(): UseWizardActions<T> {
 		}
 	}, [manager]);
 
+	const validateAll = useCallback(
+		async (options?: { updateStatuses?: boolean }) => {
+			manager.setLoadingState({ isValidating: true });
+			try {
+				return await manager.getMachine().validateAll(options);
+			} finally {
+				manager.setLoadingState({ isValidating: false });
+			}
+		},
+		[manager],
+	);
+
 	const canSubmit = useCallback(async (): Promise<boolean> => {
 		return manager.getMachine().canSubmit();
 	}, [manager]);
@@ -309,6 +321,7 @@ export function useWizardActions<T extends WizardData>(): UseWizardActions<T> {
 			setData,
 			updateField,
 			validate,
+			validateAll,
 			canSubmit,
 			submit,
 			reset,
@@ -321,6 +334,7 @@ export function useWizardActions<T extends WizardData>(): UseWizardActions<T> {
 			setData,
 			updateField,
 			validate,
+			validateAll,
 			canSubmit,
 			submit,
 			reset,

--- a/packages/react/src/use-wizard.tsx
+++ b/packages/react/src/use-wizard.tsx
@@ -2,6 +2,7 @@ import type {
 	GoToOptions,
 	StepId,
 	StepStatus,
+	ValidationSummary,
 	WizardContext,
 	WizardData,
 	WizardDefinition,
@@ -113,6 +114,9 @@ export type UpdateFieldFn<T extends WizardData> = <K extends keyof T>(
 	value: T[K],
 ) => void;
 export type ValidateFn = () => Promise<void>;
+export type ValidateAllFn = (
+	options?: { updateStatuses?: boolean },
+) => Promise<ValidationSummary>;
 export type CanSubmitFn = () => Promise<boolean>;
 export type SubmitFn = () => Promise<void>;
 export type ResetFn<T extends WizardData> = (data?: T) => void;
@@ -130,6 +134,7 @@ export interface UseWizardActions<T extends WizardData> {
 	setData: SetDataFn<T>;
 	updateField: UpdateFieldFn<T>;
 	validate: ValidateFn;
+	validateAll: ValidateAllFn;
 	canSubmit: CanSubmitFn;
 	submit: SubmitFn;
 	reset: ResetFn<T>;
@@ -359,6 +364,18 @@ export function useWizard<T extends WizardData>(
 		}
 	}, [manager]);
 
+	const validateAll = useCallback(
+		async (options?: { updateStatuses?: boolean }) => {
+			manager.setLoadingState({ isValidating: true });
+			try {
+				return await manager.getMachine().validateAll(options);
+			} finally {
+				manager.setLoadingState({ isValidating: false });
+			}
+		},
+		[manager],
+	);
+
 	const canSubmitFn = useCallback(async (): Promise<boolean> => {
 		return manager.getMachine().canSubmit();
 	}, [manager]);
@@ -525,6 +542,7 @@ export function useWizard<T extends WizardData>(
 			setData,
 			updateField,
 			validate,
+			validateAll,
 			canSubmit: canSubmitFn,
 			submit,
 			reset,
@@ -537,6 +555,7 @@ export function useWizard<T extends WizardData>(
 			setData,
 			updateField,
 			validate,
+			validateAll,
 			canSubmitFn,
 			submit,
 			reset,

--- a/packages/react/src/use-wizard.tsx
+++ b/packages/react/src/use-wizard.tsx
@@ -114,9 +114,9 @@ export type UpdateFieldFn<T extends WizardData> = <K extends keyof T>(
 	value: T[K],
 ) => void;
 export type ValidateFn = () => Promise<void>;
-export type ValidateAllFn = (
-	options?: { updateStatuses?: boolean },
-) => Promise<ValidationSummary>;
+export type ValidateAllFn = (options?: {
+	updateStatuses?: boolean;
+}) => Promise<ValidationSummary>;
 export type CanSubmitFn = () => Promise<boolean>;
 export type SubmitFn = () => Promise<void>;
 export type ResetFn<T extends WizardData> = (data?: T) => void;

--- a/packages/react/tests/use-wizard-validate-all.test.tsx
+++ b/packages/react/tests/use-wizard-validate-all.test.tsx
@@ -48,7 +48,9 @@ describe("useWizard actions.validateAll", () => {
 			}),
 		);
 
-		let summary!: Awaited<ReturnType<typeof result.current.actions.validateAll>>;
+		let summary!: Awaited<
+			ReturnType<typeof result.current.actions.validateAll>
+		>;
 		await act(async () => {
 			summary = await result.current.actions.validateAll();
 		});

--- a/packages/react/tests/use-wizard-validate-all.test.tsx
+++ b/packages/react/tests/use-wizard-validate-all.test.tsx
@@ -1,0 +1,78 @@
+import { createLinearWizard } from "@gooonzick/wizard-core";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useWizard } from "../src/use-wizard";
+
+describe("useWizard actions.validateAll", () => {
+	const createTestDefinition = () =>
+		createLinearWizard<{ name: string; email: string }>({
+			id: "test",
+			steps: [
+				{
+					id: "step1",
+					title: "Step 1",
+					validate: async (data) => ({
+						valid: !!data.name,
+						errors: data.name ? undefined : { name: "Name is required" },
+					}),
+				},
+				{
+					id: "step2",
+					title: "Step 2",
+					validate: async (data) => ({
+						valid: !!data.email,
+						errors: data.email ? undefined : { email: "Email is required" },
+					}),
+				},
+			],
+		});
+
+	it("exposes validateAll on the actions slice", async () => {
+		const { result } = renderHook(() =>
+			useWizard({
+				definition: createTestDefinition(),
+				initialData: { name: "", email: "" },
+			}),
+		);
+
+		await waitFor(() => {
+			expect(typeof result.current.actions.validateAll).toBe("function");
+		});
+	});
+
+	it("returns a summary of invalid steps", async () => {
+		const { result } = renderHook(() =>
+			useWizard({
+				definition: createTestDefinition(),
+				initialData: { name: "", email: "" },
+			}),
+		);
+
+		let summary!: Awaited<ReturnType<typeof result.current.actions.validateAll>>;
+		await act(async () => {
+			summary = await result.current.actions.validateAll();
+		});
+
+		expect(summary.valid).toBe(false);
+		expect(summary.invalidStepIds).toEqual(["step1", "step2"]);
+		expect(summary.firstInvalidStepId).toBe("step1");
+	});
+
+	it("updateStatuses:true flips invalid step statuses and re-renders", async () => {
+		const { result } = renderHook(() =>
+			useWizard({
+				definition: createTestDefinition(),
+				initialData: { name: "", email: "" },
+			}),
+		);
+
+		await act(async () => {
+			await result.current.actions.validateAll({ updateStatuses: true });
+		});
+
+		await waitFor(() => {
+			expect(result.current.state.stepStatuses.step1).toBe("error");
+			expect(result.current.state.stepStatuses.step2).toBe("error");
+		});
+	});
+});

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -118,9 +118,9 @@ export type UpdateFieldFn<T extends WizardData> = <K extends keyof T>(
 	value: T[K],
 ) => void;
 export type ValidateFn = () => Promise<void>;
-export type ValidateAllFn = (
-	options?: { updateStatuses?: boolean },
-) => Promise<ValidationSummary>;
+export type ValidateAllFn = (options?: {
+	updateStatuses?: boolean;
+}) => Promise<ValidationSummary>;
 export type CanSubmitFn = () => Promise<boolean>;
 export type SubmitFn = () => Promise<void>;
 export type ResetFn<T extends WizardData> = (data?: T) => void;

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -2,6 +2,7 @@ import type {
 	GoToOptions,
 	StepId,
 	StepStatus,
+	ValidationSummary,
 	WizardContext,
 	WizardData,
 	WizardDefinition,
@@ -117,6 +118,9 @@ export type UpdateFieldFn<T extends WizardData> = <K extends keyof T>(
 	value: T[K],
 ) => void;
 export type ValidateFn = () => Promise<void>;
+export type ValidateAllFn = (
+	options?: { updateStatuses?: boolean },
+) => Promise<ValidationSummary>;
 export type CanSubmitFn = () => Promise<boolean>;
 export type SubmitFn = () => Promise<void>;
 export type ResetFn<T extends WizardData> = (data?: T) => void;
@@ -134,6 +138,7 @@ export interface UseWizardActions<T extends WizardData> {
 	setData: SetDataFn<T>;
 	updateField: UpdateFieldFn<T>;
 	validate: ValidateFn;
+	validateAll: ValidateAllFn;
 	canSubmit: CanSubmitFn;
 	submit: SubmitFn;
 	reset: ResetFn<T>;

--- a/packages/vue/src/use-wizard.ts
+++ b/packages/vue/src/use-wizard.ts
@@ -239,6 +239,15 @@ export function useWizard<T extends WizardData>(
 		}
 	};
 
+	const validateAll = async (options?: { updateStatuses?: boolean }) => {
+		loadingState.isValidating = true;
+		try {
+			return await machine.value.validateAll(options);
+		} finally {
+			loadingState.isValidating = false;
+		}
+	};
+
 	const canSubmit = async (): Promise<boolean> => {
 		return machine.value.canSubmit();
 	};
@@ -375,6 +384,7 @@ export function useWizard<T extends WizardData>(
 		setData,
 		updateField,
 		validate,
+		validateAll,
 		canSubmit,
 		submit,
 		reset,

--- a/packages/vue/tests/use-wizard-validate-all.test.ts
+++ b/packages/vue/tests/use-wizard-validate-all.test.ts
@@ -1,0 +1,74 @@
+import { createLinearWizard } from "@gooonzick/wizard-core";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import type { UseWizardReturn } from "../src/types";
+import { useWizard } from "../src/use-wizard";
+
+interface TestData extends Record<string, unknown> {
+	name: string;
+	email: string;
+}
+
+function mountWizard(initialData: TestData) {
+	const definition = createLinearWizard<TestData>({
+		id: "test",
+		steps: [
+			{
+				id: "step1",
+				title: "Step 1",
+				validate: async (data) => ({
+					valid: !!data.name,
+					errors: data.name ? undefined : { name: "Name is required" },
+				}),
+			},
+			{
+				id: "step2",
+				title: "Step 2",
+				validate: async (data) => ({
+					valid: !!data.email,
+					errors: data.email ? undefined : { email: "Email is required" },
+				}),
+			},
+		],
+	});
+
+	let wizardRef!: UseWizardReturn<TestData>;
+	const TestComponent = defineComponent({
+		setup() {
+			const wizard = useWizard({ definition, initialData });
+			wizardRef = wizard;
+			return { wizard };
+		},
+		template: "<div></div>",
+	});
+	const wrapper = mount(TestComponent);
+	return { wrapper, wizard: wizardRef };
+}
+
+describe("useWizard actions.validateAll", () => {
+	it("exposes validateAll on the actions slice", () => {
+		const { wizard } = mountWizard({ name: "", email: "" });
+		expect(typeof wizard.actions.validateAll).toBe("function");
+	});
+
+	it("returns a summary of invalid steps", async () => {
+		const { wizard } = mountWizard({ name: "", email: "" });
+
+		const summary = await wizard.actions.validateAll();
+
+		expect(summary.valid).toBe(false);
+		expect(summary.invalidStepIds).toEqual(["step1", "step2"]);
+		expect(summary.firstInvalidStepId).toBe("step1");
+	});
+
+	it("updateStatuses:true flips invalid step statuses reactively", async () => {
+		const { wizard } = mountWizard({ name: "", email: "" });
+
+		await wizard.actions.validateAll({ updateStatuses: true });
+		await nextTick();
+
+		expect(wizard.state.stepStatuses.value.step1).toBe("error");
+		expect(wizard.state.stepStatuses.value.step2).toBe("error");
+	});
+});


### PR DESCRIPTION
## WIZ-008 — Validate All Steps

Adds `WizardMachine.validateAll(options?)` to run the validators of every **enabled** step at once and return a structured summary — for a final Review/Summary screen that shows which earlier steps still have errors and jumps to the first invalid one.

### API
```typescript
interface StepValidationSummary { stepId: StepId; valid: boolean; errors?: Record<string, string> }
interface ValidationSummary {
  valid: boolean;
  steps: StepValidationSummary[];
  firstInvalidStepId: StepId | null;
  invalidStepIds: StepId[];
}
class WizardMachine<TData> {
  validateAll(options?: { updateStatuses?: boolean }): Promise<ValidationSummary>;
}
```

### Behavior (locked decisions)
- **Dry-run by default:** does not mutate `stepStatuses` / `isValid` / `validationErrors`, emits no `onStateChange`, and is fully isolated from the plugin system.
- **Thrown validator** → caught, reported as `{ _error: <message> }` on that step; plugin `onError` is NOT dispatched.
- Steps without a validator count valid; disabled steps (static `false` or guard) are skipped.
- Iteration/`firstInvalidStepId` follow `definition.steps` insertion order (same as Progress API).
- `updateStatuses: true` → marks invalid steps `"error"` in a single state write (exactly one `onStateChange`); valid/stale steps untouched.
- Current step is included; allowed after completion.

### Integrations
- Exposed on the **`actions`** slice of the React and Vue hooks: `actions.validateAll(...)` (toggles `isValidating`). `goTo` stays on `navigation`.

### Docs & examples
- Guide: `api/core`, `api/react`, `api/vue`, and a new "Validating All Steps" section in `core-concepts`.
- Examples (react + vue): "Validate all" button on the review step listing invalid steps and jumping to the first via `navigation.goTo(id, { skipValidation: true })`.
- ROADMAP example corrected (`actions.validateAll()`), WIZ-008 marked implemented.

### Verification
- Core tests **241 passed**; React **91**; Vue **65**.
- Typecheck clean: core / react / vue / both example apps (`tsc` + `vue-tsc`).
- VitePress docs build + Biome lint: clean.

Changeset: `.changeset/wiz-008-validate-all.md` — minor bump across the fixed group (core/react/vue/state, single version).