### PR TITLE
feat(core): onDataChange event & field-level subscriptions (WIZ-010)

### DIFF
--- a/.agents/skills/wizard-library/SKILL.md
+++ b/.agents/skills/wizard-library/SKILL.md
@@ -22,6 +22,9 @@ Use this skill to execute Wizard tasks with high correctness and minimal regress
 - Keep transition logic centralized in `resolveTransition()` semantics.
 - Keep guard functions pure (boolean result, no side effects).
 - Build validators via composition (`combineValidators`, `requiredFields`, custom validator).
+- Data-change notifications (WIZ-010): `updateField` (Object.is no-op),
+  `onDataChange` event, `watchField` (core-only), and the plugin `onDataChange`
+  hook. See `references/api_reference.md`.
 
 ### React (`@gooonzick/wizard-react`)
 

--- a/.agents/skills/wizard-library/references/api_reference.md
+++ b/.agents/skills/wizard-library/references/api_reference.md
@@ -14,6 +14,9 @@ Use public exports from `@gooonzick/wizard-core`:
 
 - Builders: `createWizard`, `createLinearWizard`, `createStep`
 - Machine: `WizardMachine`, `WizardEvents`, `WizardState`
+- Data-change API (WIZ-010): `WizardMachine.updateField(field, value)` (Object.is no-op guard),
+  `WizardMachine.watchField(field, cb)` (returns an unsubscribe fn; core-only, not exposed via hooks),
+  and the `WizardEvents.onDataChange(prev, next, changedFields)` event.
 - Transitions: `resolveTransition`, `andGuards`, `orGuards`, `notGuard`, `evaluateGuard`
 - Validators: `requiredFields`, `combineValidators`, `createValidator`, `createStandardSchemaValidator`
 - Types: `WizardData`, `WizardDefinition`, `WizardStepDefinition`, `StepTransition`, `WizardContext`
@@ -105,6 +108,12 @@ call site must not switch between provider and direct mode across renders.
 
 When changing wizard behavior, verify these slices/hooks still return expected semantics.
 
+Both adapters' `useWizard` (and `<WizardProvider>`) accept an `onDataChange`
+option — `(prevData, nextData, changedFields) => void` (plain `T` params) — that
+fires on data mutations. `actions.updateField` delegates to the core
+`updateField` (Object.is no-op). `watchField` is core-only and is NOT part of the
+adapter surface.
+
 ## Typical Implementation Snippets
 
 ### Build a definition and run machine
@@ -149,6 +158,19 @@ Use context for external dependencies instead of hard-coding globals in guards/r
   mutate wizard state.
 - `updateData(updater)` takes an `(data) => data` updater and uses its return value
   directly (documented in/out contract) — it does NOT clone.
+- `updateField(field, value)` updates one top-level field with an `Object.is`
+  no-op guard: setting a field to its current value does nothing (no
+  `onStateChange`, no `onDataChange`). Produces `changedFields = [field]`.
+- `onDataChange(prevData, nextData, changedFields)` (a `WizardEvents` member)
+  fires AFTER `onStateChange` on any `updateField`/`updateData`/`setData` that
+  changes ≥1 top-level field. `changedFields` is a shallow (`Object.is`) diff of
+  top-level keys. NOT fired on `reset()`, `restore()`, or navigation. Handler
+  errors are isolated and routed to `onError` with `phase: "data"`.
+- `watchField(field, cb)` subscribes to a single field, calls back with
+  `(newValue, oldValue)`, and returns an unsubscribe function. Core-only.
+- Plugin hook `onDataChange(prevData, nextData, changedFields)` (DeepReadonly
+  payloads, fire-and-forget, errors → `onError` phase "data") is part of
+  `WizardPlugin` (WIZ-010). `ErrorContext.phase` now includes `"data"`.
 - `snapshot`, its `stepStatuses`, and `snapshot.progress` (with its `enabledStepIds`
   array) are frozen; `snapshot.data` is intentionally NOT frozen.
 

--- a/.agents/skills/wizard-library/references/architecture_and_changes.md
+++ b/.agents/skills/wizard-library/references/architecture_and_changes.md
@@ -44,6 +44,16 @@ Do not re-implement machine behavior in React/Vue adapters.
 3. Vue adapter (`useWizard` callbacks and state slices)
 4. Documentation and examples that expose callbacks
 
+When touching data-mutation events specifically (WIZ-010 `onDataChange` /
+`watchField` / plugin `onDataChange`):
+- Fire data-change notifications only from `updateField` / `updateData` /
+  `setData`, and only when the shallow top-level diff is non-empty — never from
+  `reset()`, `restore()`, or navigation (those write state directly).
+- Emit AFTER `onStateChange`, matching the `navigateToStep` precedent.
+- Isolate every subscriber (event, watcher, plugin hook): a throw routes to
+  `onError` with `phase: "data"` and must not corrupt the committed update or
+  block other subscribers.
+
 ### Change validators
 
 1. Validator utility behavior (`requiredFields`, `combineValidators`, custom validators)
@@ -87,3 +97,6 @@ Then run project quality gates:
   "Finish"). For an authoritative async answer, `await machine.getNextStepId()` and
   treat `null` as last. Do not change `isLastStep` to optimistically return `true` for
   async paths.
+- Reacting to `onDataChange` by writing a field to a freshly-allocated
+  object/array every time — it never satisfies the `Object.is` no-op guard and
+  loops. React to `changedFields` and set converging (usually primitive) values.

--- a/.changeset/wiz-010-ondatachange-field-subscriptions.md
+++ b/.changeset/wiz-010-ondatachange-field-subscriptions.md
@@ -1,0 +1,7 @@
+---
+"@gooonzick/wizard-core": minor
+"@gooonzick/wizard-react": minor
+"@gooonzick/wizard-vue": minor
+---
+
+Add `onDataChange` event, `watchField(field, cb)` method, and the `onDataChange` plugin hook (WIZ-010). Fired on data mutations (updateField/updateData/setData) with shallow-diffed `changedFields`; not fired on reset/restore. Plugin hook payloads are DeepReadonly; subscriber errors are isolated and routed to onError (phase "data").

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,14 +70,13 @@ The published version is **1.5.1** (`core`, `react`, `vue`, and `state` are fixe
 | **Reset / Cancel**        | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅           | ✅             | ✅          | ✅       | ❌                 | ❌           |
 | **State persistence**     | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅ persist   | ✅ sessions    | ✅          | ❌       | ✅ server          | ❌           |
 | **Middleware / plugins**  | ✅ WIZ-007         | ❌               | ❌                | ❌          | ❌          | ✅ actions   | ✅             | ❌          | ❌       | ❌                 | ❌           |
-| **Router integration**    | ❌                 | ❌               | ❌                | ❌          | ✅          | ❌           | ❌             | ❌          | ❌       | ❌                 | ✅           |
 | **Sub-wizards**           | ❌                 | ❌               | ❌                | ✅ nested   | ❌          | ✅ spawn     | ✅             | ✅ pages    | ❌       | ❌                 | ❌           |
 | **Validate all steps**    | ✅                 | ❌               | ❌                | ❌          | ❌          | ❌           | ❌             | ✅          | ❌       | ❌                 | ❌           |
 | **DevTools / visualizer** | ❌                 | ❌               | ❌                | ❌          | ❌          | ✅ Stately   | ✅ outline     | ✅          | ❌       | ❌                 | ❌           |
 
 ### Key Takeaway
 
-`gooonzick/wizard` already outperforms most competitors in its foundation: typing, declarative approach, framework-agnostic architecture, conditional branching, guard combinators, and Standard Schema. Its **runtime capabilities** are now complete too — navigation (including `goTo` and history), step status tracking, progress, reset/cancel, persistence, plugins, and all-steps validation (WIZ-001 through WIZ-008) have all shipped. The remaining differentiators on the horizon are router integration, sub-wizards, and DevTools/visualization — closing those will make the library an undisputed leader in its niche.
+`gooonzick/wizard` already outperforms most competitors in its foundation: typing, declarative approach, framework-agnostic architecture, conditional branching, guard combinators, and Standard Schema. Its **runtime capabilities** are now complete too — navigation (including `goTo` and history), step status tracking, progress, reset/cancel, persistence, plugins, and all-steps validation (WIZ-001 through WIZ-008) have all shipped. The remaining differentiators on the horizon are sub-wizards and DevTools/visualization — closing those will make the library an undisputed leader in its niche.
 
 ---
 
@@ -694,101 +693,7 @@ If `updateStatuses: true` — set `error` for invalid steps.
 
 ---
 
-#### WIZ-009: Router Integration
-
-**Status:** 📋 Planned
-**Priority:** 🟡 High
-**Effort:** M (4–6 hours)
-**Package:** `@gooonzick/wizard-router-react` (new package)
-
-##### Problem
-
-When using a wizard in an SPA, each step should have its own URL to support:
-
-- Browser "Back" button
-- Deeplinks (link to a specific step)
-- Refresh (page reload does not lose the current step)
-- SEO (for public wizards)
-
-Competitors `react-albus` and `@robo-wizard/react-router` solve this via React Router integration.
-
-##### Solution
-
-A separate package with two-way URL ↔ stepId synchronization.
-
-##### API
-
-```typescript
-// @gooonzick/wizard-router-react
-
-import { useRoutedWizard } from '@gooonzick/wizard-router-react';
-
-function App() {
-  const wizard = useRoutedWizard({
-    definition: signupWizard,
-    initialData: { ... },
-    routing: {
-      basePath: '/signup',               // URL prefix
-      strategy: 'path',                  // 'path' | 'hash' | 'query'
-      // path  → /signup/personal, /signup/plan
-      // hash  → /signup#personal, /signup#plan
-      // query → /signup?step=personal
-      paramName: 'step',                 // for strategy: 'query'
-      history: browserHistory,           // react-router history or window.history
-    },
-    onComplete: (data) => router.push('/dashboard'),
-  });
-}
-
-// Or a wrapper for React Router v6+
-import { WizardRoutes } from '@gooonzick/wizard-router-react';
-
-<WizardRoutes
-  definition={signupWizard}
-  basePath="/signup"
-  initialData={{ ... }}
->
-  {({ state, navigation, actions }) => (
-    <CurrentStepComponent
-      data={state.data}
-      onNext={() => navigation.goNext()}
-    />
-  )}
-</WizardRoutes>
-```
-
-##### Synchronization
-
-**URL → Machine:**
-
-- On mount: read the current URL, extract stepId, call `goTo(stepId, { skipValidation: true })`
-- On popstate (browser Back button): extract stepId, call `goPrevious()` or `goTo()`
-
-**Machine → URL:**
-
-- On every `onStateChange` → update URL via `history.pushState` or `history.replaceState`
-- `goNext()` → `pushState`
-- `goPrevious()` → `back()` or `pushState` (configurable)
-- `goTo()` → `pushState`
-- `reset()` → `replaceState` with initialStepId
-
-##### Dependencies
-
-- Depends on WIZ-002 (goTo)
-- Optional peer dependency: `react-router-dom >= 6`
-
-##### Tests
-
-- URL updates on goNext
-- Browser back → goPrevious
-- Deeplink → goTo the correct step
-- Refresh → current step is preserved
-- Invalid stepId in URL → fallback to initialStep
-- All three strategies (path / hash / query)
-
----
-
-#### WIZ-010: onDataChange Event / Field-level Subscriptions ✅
+#### WIZ-010: onDataChange Event / Field-level Subscriptions
 
 **Status:** 📋 Planned
 **Priority:** 🟠 Medium
@@ -1296,7 +1201,6 @@ Phase 3 (Ecosystem):
   WIZ-008 Validate All         ── depends on WIZ-003
 
 Phase 4 (Integrations):
-  WIZ-009 Router               ── depends on WIZ-002
   WIZ-010 onDataChange         ── independent
   WIZ-016 Analytics Plugin     ── depends on WIZ-007
 
@@ -1310,15 +1214,15 @@ Phase 5 (Advanced):
 
 ## Appendix B: Breaking Changes Summary
 
-| Task                | Breaking change                 | Mitigation                                  |
-| ------------------- | ------------------------------- | ------------------------------------------- |
-| WIZ-001 History     | `goPrevious()` changes behavior | `useHistory: boolean` option in config      |
-| WIZ-003 Step Status | New field in `WizardState`      | Additive, non-breaking                      |
-| WIZ-004 Progress    | New field in `WizardState`      | Additive, non-breaking                      |
-| WIZ-005 Reset       | New methods                     | Additive, non-breaking                      |
+| Task                | Breaking change                          | Mitigation                                  |
+| ------------------- | ---------------------------------------- | ------------------------------------------- |
+| WIZ-001 History     | `goPrevious()` changes behavior          | `useHistory: boolean` option in config      |
+| WIZ-003 Step Status | New field in `WizardState`               | Additive, non-breaking                      |
+| WIZ-004 Progress    | New field in `WizardState`               | Additive, non-breaking                      |
+| WIZ-005 Reset       | New methods                              | Additive, non-breaking                      |
 | WIZ-006 Persistence | New instance methods (serialize/restore) | Additive, non-breaking                      |
-| WIZ-007 Plugins     | New `use()` method              | Additive, non-breaking                      |
-| WIZ-011 Sub-wizards | New step type                   | Additive, non-breaking                      |
-| WIZ-013 Lazy Steps  | Steps can be a function         | Requires `typeof step === 'function'` check |
+| WIZ-007 Plugins     | New `use()` method                       | Additive, non-breaking                      |
+| WIZ-011 Sub-wizards | New step type                            | Additive, non-breaking                      |
+| WIZ-013 Lazy Steps  | Steps can be a function                  | Requires `typeof step === 'function'` check |
 
 **Recommendation:** combine Phase 1 + Phase 2 into a single minor release (v1.1.0), Phase 3 into v1.2.0, Phase 4 into v1.3.0, and Phase 5 into v2.0.0 (if there is a breaking change with `useHistory` enabled by default).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -35,6 +35,7 @@
 | State Persistence (WIZ-006)                           | ✅     | `core`  |
 | Plugin System (WIZ-007)                               | ✅     | `core`  |
 | Validate All Steps (WIZ-008)                          | ✅     | `core`  |
+| onDataChange / Field Subscriptions (WIZ-010)          | ✅     | `core`  |
 
 ### Architectural Decisions
 
@@ -528,7 +529,14 @@ interface WizardPlugin<TData = unknown> {
   // On reset/cancel.
   onReset?: () => void | Promise<void>;
 
-  // NOTE: onDataChange is NOT included — deferred to WIZ-010.
+  // After a data mutation that changed at least one top-level field (WIZ-010).
+  // Data params are DeepReadonly; fire-and-forget; throws routed to onError
+  // (phase "data").
+  onDataChange?: (
+    prevData: DeepReadonly<TData>,
+    nextData: DeepReadonly<TData>,
+    changedFields: readonly (keyof TData)[],
+  ) => void | Promise<void>;
 
   // Cleanup when the machine is destroyed.
   destroy?: () => void | Promise<void>;
@@ -544,7 +552,7 @@ interface TransitionEvent<TData> {
 
 interface ErrorContext<TData> {
   stepId: StepId;
-  phase: "validation" | "transition" | "lifecycle" | "submit";
+  phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
   data: DeepReadonly<TData>;
 }
 
@@ -564,7 +572,7 @@ class WizardMachine<TData> {
 }
 ```
 
-> **Note:** The builder-level `.use()` from the original spec was NOT implemented. Registration goes through the constructor's 5th argument or `machine.use()` after construction. `onDataChange` was also not implemented — it is deferred to WIZ-010.
+> **Note:** The builder-level `.use()` from the original spec was NOT implemented. Registration goes through the constructor's 5th argument or `machine.use()` after construction. The `onDataChange` plugin hook shipped in WIZ-010.
 
 ##### Execution Order
 
@@ -772,11 +780,12 @@ import { WizardRoutes } from '@gooonzick/wizard-router-react';
 
 ---
 
-#### WIZ-010: onDataChange Event / Field-level Subscriptions
+#### WIZ-010: onDataChange Event / Field-level Subscriptions ✅
 
 **Priority:** 🟠 Medium
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core`
+**Status:** ✅ DONE
 
 ##### Problem
 
@@ -825,6 +834,16 @@ When `updateData(updater)` is called → shallow diff of keys between `prevData`
 ##### Note: Plugin Integration (non-breaking)
 
 WIZ-010 should also add `onDataChange` to the `WizardPlugin` interface so plugins can react to data mutations without subscribing to the full `onStateChange`. This is an additive, non-breaking extension of the plugin API shipped in WIZ-007. The existing plugin hook set intentionally omitted `onDataChange` pending this work.
+
+##### Shipped vs. specced deltas
+
+- The config interface is `WizardEvents<T>` (this spec called it `WizardCallbacks`); its `onDataChange` params are plain `T`, matching the other machine events.
+- `updateField(field, value)` was added to the **core** machine (previously framework-only sugar over `updateData`); the React/Vue `updateField` hooks now delegate to it, so `changedFields = [field]` is authoritative.
+- `setData` also fires `onDataChange` (shallow diff of top-level keys) — beyond the two methods named in the original spec — so plugins/watchers react to every data mutation.
+- A no-op `updateField` (new value is `Object.is`-equal to the current one) now fires **nothing** — no `onStateChange`, no `onDataChange`, no watchers/plugin hook. Previously the framework `updateData` sugar always created a new object and fired `onStateChange`.
+- The **plugin** `onDataChange` receives `DeepReadonly<TData>` data params (consistent with WIZ-007), and a new `"data"` value was added to `ErrorContext.phase` so isolated subscriber throws are attributed correctly via `onError`.
+- `reset()` and `restore()` do NOT fire `onDataChange` / watchers / the plugin hook.
+- `watchField` is core-only for this ticket (reachable via `manager.getMachine().watchField(...)`); the framework surface only gains the `onDataChange` option.
 
 ---
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -89,12 +89,12 @@ The published version is **1.5.1** (`core`, `react`, `vue`, and `state` are fixe
 
 ---
 
-#### WIZ-001: Navigation History Stack ✅
+#### WIZ-001: Navigation History Stack
 
+**Status:** ✅ Done
 **Priority:** 🔴 Critical
 **Effort:** S (2–4 hours)
 **Package:** `@gooonzick/wizard-core`
-**Status:** ✅ Implemented
 
 ##### Problem
 
@@ -144,12 +144,12 @@ class WizardMachine<TData> {
 
 ---
 
-#### WIZ-002: goTo(stepId) — Arbitrary Navigation ✅
+#### WIZ-002: goTo(stepId) — Arbitrary Navigation
 
+**Status:** ✅ Done
 **Priority:** 🔴 Critical
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core`
-**Status:** Implemented
 
 ##### Problem
 
@@ -204,8 +204,9 @@ navigation.goTo('personal', { skipValidation: true });
 
 ---
 
-#### WIZ-003: Step Status Tracking ✅
+#### WIZ-003: Step Status Tracking
 
+**Status:** ✅ Done
 **Priority:** 🔴 Critical
 **Effort:** S (3–4 hours)
 **Package:** `@gooonzick/wizard-core`
@@ -276,12 +277,12 @@ When the machine is created, all steps receive the `pristine` status, except `in
 
 ---
 
-#### WIZ-004: Progress API ✅
+#### WIZ-004: Progress API
 
+**Status:** ✅ Done
 **Priority:** 🟡 High
 **Effort:** XS (1–2 hours)
 **Package:** `@gooonzick/wizard-core`
-**Status:** ✅ Implemented
 
 ##### Problem
 
@@ -328,8 +329,9 @@ The order is determined by traversing the transition graph from `initialStepId` 
 
 ---
 
-#### WIZ-005: Reset / Cancel ✅ Implemented
+#### WIZ-005: Reset / Cancel
 
+**Status:** ✅ Done
 **Priority:** 🟡 High
 **Effort:** XS (1–2 hours)
 **Package:** `@gooonzick/wizard-core`, `@gooonzick/wizard-react`, `@gooonzick/wizard-vue`
@@ -407,12 +409,12 @@ actions.cancel();
 
 ---
 
-#### WIZ-006: State Persistence (Serialize / Restore) ✅ Implemented
+#### WIZ-006: State Persistence (Serialize / Restore)
 
+**Status:** ✅ Done (core serialize/restore; persistence adapters & autoSave deferred — see "Not Built")
 **Priority:** 🟡 High
 **Effort:** M (4–6 hours)
 **Package:** `@gooonzick/wizard-core`
-**Status:** ✅ Implemented (core serialize/restore only — see "Not built" below)
 
 ##### Problem
 
@@ -490,7 +492,7 @@ The following from the original proposal were NOT implemented:
 
 #### WIZ-007: Middleware / Plugin System
 
-**Status:** ✅ DONE
+**Status:** ✅ Done
 **Priority:** 🟡 High
 **Package:** `@gooonzick/wizard-core`
 
@@ -621,6 +623,7 @@ All hook dispatch, veto, ordering, error isolation, busy-guard re-entrancy, and 
 
 #### WIZ-008: Validate All Steps
 
+**Status:** ✅ Done
 **Priority:** 🟡 High
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core`
@@ -693,6 +696,7 @@ If `updateStatuses: true` — set `error` for invalid steps.
 
 #### WIZ-009: Router Integration
 
+**Status:** 📋 Planned
 **Priority:** 🟡 High
 **Effort:** M (4–6 hours)
 **Package:** `@gooonzick/wizard-router-react` (new package)
@@ -786,6 +790,7 @@ import { WizardRoutes } from '@gooonzick/wizard-router-react';
 
 #### WIZ-010: onDataChange Event / Field-level Subscriptions ✅
 
+**Status:** 📋 Planned
 **Priority:** 🟠 Medium
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core`
@@ -857,6 +862,7 @@ WIZ-010 should also add `onDataChange` to the `WizardPlugin` interface so plugin
 
 #### WIZ-011: Sub-wizards (Nested Wizards)
 
+**Status:** 📋 Planned
 **Priority:** 🟠 Medium
 **Effort:** L (8–12 hours)
 **Package:** `@gooonzick/wizard-core`
@@ -946,6 +952,7 @@ Sub-wizard steps contribute to the overall parent progress. One `documents` step
 
 #### WIZ-012: DevTools / Mermaid Export
 
+**Status:** 📋 Planned
 **Priority:** 🟠 Medium
 **Effort:** M (4–6 hours)
 **Package:** `@gooonzick/wizard-devtools` (new package)
@@ -1014,6 +1021,7 @@ const dot = toDot(signupWizard);
 
 #### WIZ-013: Async Step Loading (Lazy Steps)
 
+**Status:** 📋 Planned
 **Priority:** 🟢 Low
 **Effort:** M (4–5 hours)
 **Package:** `@gooonzick/wizard-core`
@@ -1070,6 +1078,7 @@ interface WizardState<TData> {
 
 #### WIZ-014: Svelte Integration
 
+**Status:** 📋 Planned
 **Priority:** 🟢 Low
 **Effort:** M (4–6 hours)
 **Package:** `@gooonzick/wizard-svelte` (new package)
@@ -1132,6 +1141,7 @@ A Svelte store wrapper around `WizardMachine`.
 
 #### WIZ-015: Solid.js Integration
 
+**Status:** 📋 Planned
 **Priority:** 🟢 Low
 **Effort:** M (4–6 hours)
 **Package:** `@gooonzick/wizard-solid` (new package)
@@ -1190,6 +1200,7 @@ function App() {
 
 #### WIZ-016: Analytics Helpers
 
+**Status:** 📋 Planned
 **Priority:** 🟢 Low
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core` (as a built-in plugin)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -37,6 +37,10 @@
 | Validate All Steps (WIZ-008)                          | ✅     | `core`  |
 | onDataChange / Field Subscriptions (WIZ-010)          | ✅     | `core`  |
 
+### Current Release
+
+The published version is **1.5.1** (`core`, `react`, `vue`, and `state` are fixed-versioned together). The WIZ-001..008 runtime foundation above has shipped and was subsequently hardened by a pre-release audit covering concurrency/veto-safety, resolver-safety, StrictMode-safe React/Vue bindings, and real-machine state tests.
+
 ### Architectural Decisions
 
 - **Core** (`WizardMachine`) — a finite state machine operating on `WizardDefinition<TData>`
@@ -60,20 +64,20 @@
 | Builder pattern           | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅ setup()   | ✅ createSpell | ❌ JSON     | ❌       | ❌                 |
 | Schema validation         | ✅ Standard Schema | ❌               | ❌                | ❌          | ❌          | ❌ (DIY)     | ❌             | ✅ built-in | ✅       | ❌                 | ❌           |
 | **Navigation history**    | ✅                 | ❌               | ❌                | ✅ 2 stacks | ✅ history  | ✅           | ✅             | ✅          | ❌       | ❌                 | ❌           |
-| **goTo(stepId)**          | ❌                 | ❌               | ✅                | ❌          | ✅ push(id) | ✅           | ✅             | ✅          | ❌       | ❌                 | ❌           |
+| **goTo(stepId)**          | ✅                 | ❌               | ✅                | ❌          | ✅ push(id) | ✅           | ✅             | ✅          | ❌       | ❌                 | ❌           |
 | **Step status tracking**  | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅ (DIY)     | ✅             | ✅          | ❌       | ❌                 | ❌           |
 | **Progress API**          | ✅                 | ❌               | ❌                | ❌          | ❌          | ❌           | ❌             | ✅          | ❌       | ✅                 | ❌           |
-| **Reset / Cancel**        | ❌                 | ❌               | ❌                | ❌          | ❌          | ✅           | ✅             | ✅          | ✅       | ❌                 | ❌           |
+| **Reset / Cancel**        | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅           | ✅             | ✅          | ✅       | ❌                 | ❌           |
 | **State persistence**     | ✅                 | ❌               | ❌                | ❌          | ❌          | ✅ persist   | ✅ sessions    | ✅          | ❌       | ✅ server          | ❌           |
 | **Middleware / plugins**  | ✅ WIZ-007         | ❌               | ❌                | ❌          | ❌          | ✅ actions   | ✅             | ❌          | ❌       | ❌                 | ❌           |
 | **Router integration**    | ❌                 | ❌               | ❌                | ❌          | ✅          | ❌           | ❌             | ❌          | ❌       | ❌                 | ✅           |
 | **Sub-wizards**           | ❌                 | ❌               | ❌                | ✅ nested   | ❌          | ✅ spawn     | ✅             | ✅ pages    | ❌       | ❌                 | ❌           |
-| **Validate all steps**    | ❌                 | ❌               | ❌                | ❌          | ❌          | ❌           | ❌             | ✅          | ❌       | ❌                 | ❌           |
+| **Validate all steps**    | ✅                 | ❌               | ❌                | ❌          | ❌          | ❌           | ❌             | ✅          | ❌       | ❌                 | ❌           |
 | **DevTools / visualizer** | ❌                 | ❌               | ❌                | ❌          | ❌          | ✅ Stately   | ✅ outline     | ✅          | ❌       | ❌                 | ❌           |
 
 ### Key Takeaway
 
-`gooonzick/wizard` already outperforms most competitors in its foundation: typing, declarative approach, framework-agnostic architecture, conditional branching, guard combinators, and Standard Schema. However, it lags behind in **runtime capabilities** — navigation, step states, persistence, and extensibility. Closing these gaps will make the library an undisputed leader in its niche.
+`gooonzick/wizard` already outperforms most competitors in its foundation: typing, declarative approach, framework-agnostic architecture, conditional branching, guard combinators, and Standard Schema. Its **runtime capabilities** are now complete too — navigation (including `goTo` and history), step status tracking, progress, reset/cancel, persistence, plugins, and all-steps validation (WIZ-001 through WIZ-008) have all shipped. The remaining differentiators on the horizon are router integration, sub-wizards, and DevTools/visualization — closing those will make the library an undisputed leader in its niche.
 
 ---
 
@@ -298,7 +302,7 @@ interface WizardProgress {
   enabledStepIds: StepId[]; // ordered list of enabled steps
   percentage: number; // 0–100, completedSteps / enabledSteps * 100
   isFirstStep: boolean; // currentStepId === definition.initialStepId
-  isLastStep: boolean; // no resolvable next step (navigation-graph based)
+  isLastStep: boolean; // true only when there is no synchronously-resolvable next step; async-resolved next ⇒ false (use getNextStepId())
 }
 
 interface WizardState<TData> {

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -437,6 +437,10 @@ class WizardMachine<T> {
   // Data operations
   updateData(updater: (data: T) => T): void;
   setData(data: T): void;
+  /** Update one top-level field. Object.is no-op guard. Fires onDataChange with changedFields=[field]. (WIZ-010) */
+  updateField<K extends keyof T>(field: K, value: T[K]): void;
+  /** Subscribe to one field. Returns an unsubscribe function. (WIZ-010) */
+  watchField<K extends keyof T>(field: K, callback: (newValue: T[K], oldValue: T[K]) => void): () => void;
 
   // Validation & submission
   validate(): Promise<ValidationResult>;
@@ -506,6 +510,17 @@ interface WizardEvents<T> {
   /** Fired after `reset()` (and after `cancel()`'s implicit reset). */
   onReset?: () => void;
   onError?: (error: Error) => void;
+  /**
+   * Fired after a data mutation (updateField/updateData/setData) that changes
+   * at least one top-level field. Fires after onStateChange; NOT fired on
+   * reset(), restore(), or navigation. changedFields are the changed top-level
+   * keys (Object.is). (WIZ-010)
+   */
+  onDataChange?: (
+    prevData: T,
+    nextData: T,
+    changedFields: (keyof T)[],
+  ) => void;
 }
 ```
 
@@ -854,6 +869,15 @@ machine.updateData((d) => ({ ...d, name: "John" }));
 // Replace all data
 machine.setData({ name: "Jane", email: "jane@example.com" });
 
+// Update one field (no-op if the value is Object.is-equal to the current value)
+machine.updateField("name", "John");
+
+// React to data changes (fires after onStateChange; not on reset/restore/navigation)
+const stop = machine.watchField("name", (next, prev) => {
+  console.log(`name: ${prev} → ${next}`);
+});
+stop(); // unsubscribe
+
 // Validate
 const result = await machine.validate();
 if (result.valid) {
@@ -922,6 +946,12 @@ interface WizardPlugin<TData = unknown> {
   ): void | Promise<void>;
   onComplete?(data: DeepReadonly<TData>): void | Promise<void>;
   onReset?(): void | Promise<void>;
+  /** Fired after a data mutation that changed ≥1 top-level field. Fire-and-forget; DeepReadonly payloads; errors routed to onError phase "data". (WIZ-010) */
+  onDataChange?(
+    prevData: DeepReadonly<TData>,
+    nextData: DeepReadonly<TData>,
+    changedFields: readonly (keyof TData)[],
+  ): void | Promise<void>;
   destroy?(): void | Promise<void>;
 }
 ```
@@ -947,7 +977,7 @@ Context passed to `onError`.
 ```ts
 interface ErrorContext<TData> {
   stepId: StepId;
-  phase: "validation" | "transition" | "lifecycle" | "submit";
+  phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
   data: DeepReadonly<TData>;
 }
 ```

--- a/docs/api/react.md
+++ b/docs/api/react.md
@@ -23,6 +23,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /**
    * Plugins registered once at machine creation (reference-stable — read once,
    * NOT reactive). Define them outside render or memoize them.
@@ -164,6 +165,7 @@ interface WizardProviderProps<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
   children: React.ReactNode;

--- a/docs/api/vue.md
+++ b/docs/api/vue.md
@@ -23,6 +23,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /**
    * Plugins registered once at machine creation (reference-stable — read once,
    * NOT reactive). Define them outside setup or hoist them.

--- a/docs/core-concepts.md
+++ b/docs/core-concepts.md
@@ -369,6 +369,11 @@ interface WizardEvents<T> {
   onSubmit?: (stepId: string, data: T) => void;
   onComplete?: (data: T) => void;
   onError?: (error: Error) => void;
+  onDataChange?: (
+    prevData: T,
+    nextData: T,
+    changedFields: (keyof T)[],
+  ) => void;
 }
 ```
 
@@ -385,6 +390,30 @@ const machine = new WizardMachine(definition, context, initialData, {
     showErrorMessage(error.message);
   },
 });
+```
+
+### Reacting to data changes
+
+`onDataChange` fires after any data mutation (`updateField`, `updateData`, or `setData`) that actually changes at least one top-level field, with the previous data, the next data, and the list of changed keys. It fires **after** `onStateChange`, and is **not** fired by `reset()`, `restore()`, or navigation. A no-op update (setting a field to its current value) fires nothing.
+
+```typescript
+const machine = new WizardMachine(definition, context, initialData, {
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      // Recompute a dependent field when the plan changes.
+      machine.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+```
+
+For a single field, `watchField` subscribes to just that key and returns an unsubscribe function (core-only; not exposed through the React/Vue hooks):
+
+```typescript
+const stop = machine.watchField("email", (newEmail, oldEmail) => {
+  console.log(`email changed: ${oldEmail} → ${newEmail}`);
+});
+// later: stop();
 ```
 
 ## 10. Type Safety

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,7 +3,7 @@
 
 Plugins let you intercept wizard transitions and lifecycle events globally, across every step — ideal for analytics, logging, error reporting, and auto-save. A plugin is a plain object implementing the `WizardPlugin` interface; you register instances on the machine.
 
-> `onDataChange` is **not** part of the plugin interface yet — it is deferred to WIZ-010 and will be added as a non-breaking extension.
+> `onDataChange(prevData, nextData, changedFields)` is part of the plugin interface (WIZ-010). It fires after any data mutation (`updateField` / `updateData` / `setData`) that changes at least one top-level field, with `DeepReadonly` data payloads. It is fire-and-forget (may be async) and isolated — a throw or rejection is routed to `onError` with `phase: "data"`.
 
 ## The `WizardPlugin` Interface
 
@@ -31,6 +31,13 @@ interface WizardPlugin<TData = unknown> {
 
   onReset?(): void | Promise<void>;
 
+  /** Fired after a data mutation that changed at least one top-level field. */
+  onDataChange?(
+    prevData: DeepReadonly<TData>,
+    nextData: DeepReadonly<TData>,
+    changedFields: readonly (keyof TData)[],
+  ): void | Promise<void>;
+
   destroy?(): void | Promise<void>;
 }
 ```
@@ -52,7 +59,7 @@ interface TransitionEvent<TData> {
 /** Context passed to a plugin's onError hook. */
 interface ErrorContext<TData> {
   stepId: StepId;
-  phase: "validation" | "transition" | "lifecycle" | "submit";
+  phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
   data: DeepReadonly<TData>;
 }
 

--- a/docs/react-integration.md
+++ b/docs/react-integration.md
@@ -117,6 +117,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
 }
@@ -183,7 +184,23 @@ loading.isNavigating; // Navigation in progress?
 actions.updateData((data) => ({ ...data, name: "John" }));
 actions.setData(completeData);
 actions.updateField("name", "John");
+```
 
+React to data changes by passing `onDataChange` to `useWizard`. It fires after any `updateField` / `updateData` / `setData` that changes a top-level field (after `onStateChange`; not on reset/restore/navigation):
+
+```tsx
+const { actions } = useWizard({
+  definition,
+  initialData,
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      actions.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+```
+
+```typescript
 // Validation
 actions.validate(); // Manually validate (result goes to validation slice)
 actions.validateAll(); // Dry-run all enabled steps → ValidationSummary

--- a/docs/vue-integration.md
+++ b/docs/vue-integration.md
@@ -162,6 +162,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
 }
@@ -228,7 +229,25 @@ loading.isNavigating.value; // Navigation in progress? (ComputedRef)
 actions.updateData((data) => ({ ...data, name: "John" }));
 actions.setData(completeData);
 actions.updateField("name", "John");
+```
 
+React to data changes by passing `onDataChange` to `useWizard`. It fires after any `updateField` / `updateData` / `setData` that changes a top-level field (after `onStateChange`; not on reset/restore/navigation):
+
+```vue
+<script setup lang="ts">
+const { actions } = useWizard({
+  definition,
+  initialData,
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      actions.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+</script>
+```
+
+```typescript
 // Validation
 await actions.validate(); // Manually validate (result goes to validation slice)
 await actions.validateAll(); // Dry-run all enabled steps → ValidationSummary

--- a/examples/react-examples/src/App.tsx
+++ b/examples/react-examples/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { DataChangeExample } from "./data-change-example";
 import { HistoryExample } from "./history-example";
 import { PluginsExample } from "./plugins-example";
 import { ProviderExample } from "./provider-example";
@@ -12,7 +13,8 @@ type View =
 	| "history"
 	| "reset-cancel"
 	| "persistence"
-	| "plugins";
+	| "plugins"
+	| "data-change";
 
 export function App() {
 	const [view, setView] = useState<View>("wizard");
@@ -24,6 +26,7 @@ export function App() {
 		{ id: "reset-cancel", label: "Reset & Cancel" },
 		{ id: "persistence", label: "State Persistence" },
 		{ id: "plugins", label: "Plugins" },
+		{ id: "data-change", label: "Data Change" },
 	];
 
 	return (
@@ -50,6 +53,7 @@ export function App() {
 			{view === "reset-cancel" && <ResetCancelExample />}
 			{view === "persistence" && <StatePersistenceExample />}
 			{view === "plugins" && <PluginsExample />}
+			{view === "data-change" && <DataChangeExample />}
 		</div>
 	);
 }

--- a/examples/react-examples/src/data-change-example.tsx
+++ b/examples/react-examples/src/data-change-example.tsx
@@ -1,0 +1,246 @@
+import { createWizard } from "@gooonzick/wizard-core";
+import { useWizard } from "@gooonzick/wizard-react";
+import type React from "react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+// ── Data type ──────────────────────────────────────────────────────
+
+type OrderData = {
+	plan: "basic" | "pro";
+	quantity: number;
+	unitPrice: number; // auto-filled from plan
+	total: number; // recomputed = quantity * unitPrice
+	needsInvoice: boolean;
+	companyName: string; // cleared when needsInvoice turns off
+};
+
+const PRICES: Record<OrderData["plan"], number> = {
+	basic: 10,
+	pro: 25,
+};
+
+// ── Wizard definition ───────────────────────────────────────────────
+// Single step: the point of this example is the data cascade driven by
+// `onDataChange`, not navigation.
+
+const orderWizard = createWizard<OrderData>("order")
+	.initialStep("order")
+	.step("order", (s) => s.title("Order Details"))
+	.build();
+
+const initialData: OrderData = {
+	plan: "basic",
+	quantity: 1,
+	unitPrice: PRICES.basic,
+	total: PRICES.basic * 1,
+	needsInvoice: false,
+	companyName: "",
+};
+
+// ── Step fields ────────────────────────────────────────────────────
+
+function OrderFields({
+	data,
+	onChange,
+}: {
+	data: OrderData;
+	onChange: <K extends keyof OrderData>(field: K, value: OrderData[K]) => void;
+}) {
+	return (
+		<div className="space-y-4">
+			<div className="space-y-3">
+				{(["basic", "pro"] as const).map((p) => (
+					<label
+						key={p}
+						className={`flex items-center gap-3 rounded-lg border p-4 cursor-pointer transition ${
+							data.plan === p
+								? "border-blue-500 bg-blue-50"
+								: "border-gray-200 hover:bg-gray-50"
+						}`}
+					>
+						<input
+							type="radio"
+							name="plan"
+							value={p}
+							checked={data.plan === p}
+							onChange={() => onChange("plan", p)}
+							className="accent-blue-600"
+						/>
+						<div>
+							<div className="font-medium capitalize">{p}</div>
+							<div className="text-xs text-gray-500">${PRICES[p]} / unit</div>
+						</div>
+					</label>
+				))}
+			</div>
+
+			<label className="block">
+				<span className="text-sm font-medium text-gray-700">Quantity</span>
+				<input
+					type="number"
+					min={1}
+					className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+					value={data.quantity}
+					onChange={(e) => onChange("quantity", Number(e.target.value) || 1)}
+				/>
+			</label>
+
+			<div className="grid grid-cols-2 gap-4 text-sm">
+				<div>
+					<span className="text-gray-500">Unit price (auto-filled)</span>
+					<p className="font-mono font-medium">${data.unitPrice}</p>
+				</div>
+				<div>
+					<span className="text-gray-500">Total (recomputed)</span>
+					<p className="font-mono font-medium">${data.total}</p>
+				</div>
+			</div>
+
+			<label className="flex items-center gap-2 text-sm">
+				<input
+					type="checkbox"
+					checked={data.needsInvoice}
+					onChange={(e) => onChange("needsInvoice", e.target.checked)}
+					className="accent-blue-600"
+				/>
+				<span>I need an invoice</span>
+			</label>
+
+			<label className="block">
+				<span className="text-sm font-medium text-gray-700">Company name</span>
+				<input
+					type="text"
+					disabled={!data.needsInvoice}
+					className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 disabled:text-gray-400"
+					value={data.companyName}
+					onChange={(e) => onChange("companyName", e.target.value)}
+					placeholder="Acme Inc."
+				/>
+			</label>
+		</div>
+	);
+}
+
+// ── Data change log ──────────────────────────────────────────────────
+
+type LogEntry = {
+	id: number;
+	changedFields: (keyof OrderData)[];
+	text: string;
+};
+
+function DataChangeLog({ entries }: { entries: LogEntry[] }) {
+	return (
+		<Card className="p-5">
+			<h3 className="text-sm font-semibold text-gray-700 mb-3">
+				Data change log
+			</h3>
+			{entries.length === 0 ? (
+				<p className="text-xs text-gray-400 italic">
+					Edit a field to fire <code>onDataChange</code>
+				</p>
+			) : (
+				<ul className="space-y-1.5">
+					{entries
+						.slice()
+						.reverse()
+						.map((e) => (
+							<li
+								key={e.id}
+								className="text-xs rounded-md border px-2 py-1.5 bg-blue-50 text-blue-700 border-blue-200"
+							>
+								<span className="font-mono font-semibold mr-2">
+									{e.changedFields.join(", ")}
+								</span>
+								{e.text}
+							</li>
+						))}
+				</ul>
+			)}
+			<p className="mt-3 text-xs text-gray-400">
+				Changing <strong>plan</strong> auto-fills <strong>unitPrice</strong>,
+				which (with <strong>quantity</strong>) recomputes <strong>total</strong>
+				. Unchecking <strong>needsInvoice</strong> clears{" "}
+				<strong>companyName</strong>. Each cascade step is its own{" "}
+				<code>onDataChange</code> round, and terminates via the{" "}
+				<code>Object.is</code> no-op guard on <code>updateField</code>.
+			</p>
+		</Card>
+	);
+}
+
+// ── Main component ─────────────────────────────────────────────────
+
+export const DataChangeExample: React.FC = () => {
+	const [log, setLog] = useState<LogEntry[]>([]);
+
+	const { actions, state } = useWizard({
+		definition: orderWizard,
+		initialData,
+		onDataChange: (_prev, next, changedFields) => {
+			// Auto-fill the dependent unit price when the plan changes.
+			if (changedFields.includes("plan")) {
+				actions.updateField("unitPrice", PRICES[next.plan]);
+			}
+			// Recompute the total whenever quantity or unitPrice changes.
+			if (
+				changedFields.includes("quantity") ||
+				changedFields.includes("unitPrice")
+			) {
+				actions.updateField("total", next.quantity * next.unitPrice);
+			}
+			// Clear the dependent company name when the invoice flag turns off.
+			if (changedFields.includes("needsInvoice") && !next.needsInvoice) {
+				actions.updateField("companyName", "");
+			}
+
+			setLog((prevLog) => [
+				...prevLog,
+				{
+					id: prevLog.length,
+					changedFields,
+					text: `→ unitPrice=${next.unitPrice}, total=${next.total}, companyName="${next.companyName}"`,
+				},
+			]);
+		},
+	});
+
+	return (
+		<div className="min-h-screen bg-gray-50 py-8 px-4">
+			<div className="max-w-5xl mx-auto">
+				<div className="mb-8">
+					<h1 className="text-3xl font-bold text-gray-900">Data Change</h1>
+					<p className="text-gray-600 mt-1">
+						Demonstrates <code>onDataChange</code> driving dependent-field
+						auto-fill, recomputation, and cleanup via <code>updateField</code>{" "}
+						(WIZ-010).
+					</p>
+				</div>
+
+				<div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-6">
+					<Card className="p-8">
+						<h2 className="text-xl font-semibold mb-4">
+							{state.currentStep.meta?.title}
+						</h2>
+
+						<OrderFields data={state.data} onChange={actions.updateField} />
+
+						<div className="flex flex-wrap gap-3 mt-8 pt-6 border-t">
+							<Button onClick={() => actions.submit()}>Complete order</Button>
+						</div>
+
+						{state.isCompleted && (
+							<p className="mt-4 text-sm text-emerald-700 font-medium">
+								✓ Order submitted.
+							</p>
+						)}
+					</Card>
+
+					<DataChangeLog entries={log} />
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/examples/vue-examples/src/App.vue
+++ b/examples/vue-examples/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 import ApproachToggle from "./components/approach-toggle.vue";
+import DataChangeExample from "./wizard-example/data-change-example.vue";
 import FieldBindingExample from "./wizard-example/field-binding-example.vue";
 import HistoryExample from "./wizard-example/history-example.vue";
 import PluginsExample from "./wizard-example/plugins-example.vue";
@@ -16,7 +17,8 @@ type Approach =
 	| "history"
 	| "reset-cancel"
 	| "persistence"
-	| "plugins";
+	| "plugins"
+	| "data-change";
 
 const approaches: Approach[] = [
 	"use-wizard",
@@ -26,6 +28,7 @@ const approaches: Approach[] = [
 	"reset-cancel",
 	"persistence",
 	"plugins",
+	"data-change",
 ];
 
 const approach = ref<Approach>("use-wizard");
@@ -61,6 +64,7 @@ watch(approach, (newVal) => {
 			<ResetCancelExample v-else-if="approach === 'reset-cancel'" />
 			<StatePersistenceExample v-else-if="approach === 'persistence'" />
 			<PluginsExample v-else-if="approach === 'plugins'" />
+			<DataChangeExample v-else-if="approach === 'data-change'" />
 		</div>
 	</div>
 </template>

--- a/examples/vue-examples/src/components/approach-toggle.vue
+++ b/examples/vue-examples/src/components/approach-toggle.vue
@@ -9,7 +9,8 @@ type Approach =
 	| "history"
 	| "reset-cancel"
 	| "persistence"
-	| "plugins";
+	| "plugins"
+	| "data-change";
 
 interface Props {
 	modelValue: Approach;
@@ -68,6 +69,12 @@ defineEmits<
 			@click="$emit('update:modelValue', 'plugins')"
 		>
 			Plugins
+		</Button>
+		<Button
+			:variant="modelValue === 'data-change' ? 'default' : 'outline'"
+			@click="$emit('update:modelValue', 'data-change')"
+		>
+			Data Change
 		</Button>
 	</div>
 </template>

--- a/examples/vue-examples/src/wizard-example/data-change-example.vue
+++ b/examples/vue-examples/src/wizard-example/data-change-example.vue
@@ -1,0 +1,243 @@
+<script setup lang="ts">
+import { createWizard } from "@gooonzick/wizard-core";
+import { useWizard } from "@gooonzick/wizard-vue";
+import { ref } from "vue";
+import Button from "@/components/ui/button.vue";
+import Card from "@/components/ui/card.vue";
+
+// ── Data type ──────────────────────────────────────────────────────
+
+type OrderData = {
+	plan: "basic" | "pro";
+	quantity: number;
+	unitPrice: number; // auto-filled from plan
+	total: number; // recomputed = quantity * unitPrice
+	needsInvoice: boolean;
+	companyName: string; // cleared when needsInvoice turns off
+};
+
+const PRICES: Record<OrderData["plan"], number> = {
+	basic: 10,
+	pro: 25,
+};
+
+// ── Wizard definition ───────────────────────────────────────────────
+// Single step: the point of this example is the data cascade driven by
+// `onDataChange`, not navigation.
+
+const orderWizard = createWizard<OrderData>("order")
+	.initialStep("order")
+	.step("order", (s) => s.title("Order Details"))
+	.build();
+
+const initialData: OrderData = {
+	plan: "basic",
+	quantity: 1,
+	unitPrice: PRICES.basic,
+	total: PRICES.basic * 1,
+	needsInvoice: false,
+	companyName: "",
+};
+
+// ── Data change log ──────────────────────────────────────────────────
+
+type LogEntry = {
+	id: number;
+	changedFields: (keyof OrderData)[];
+	text: string;
+};
+
+const log = ref<LogEntry[]>([]);
+
+const append = (entry: Omit<LogEntry, "id">) => {
+	log.value = [...log.value, { ...entry, id: log.value.length }];
+};
+
+// ── Composable ─────────────────────────────────────────────────────
+
+const { actions, state } = useWizard({
+	definition: orderWizard,
+	initialData,
+	onDataChange: (prev, next, changedFields) => {
+		// Auto-fill the dependent unit price when the plan changes.
+		if (changedFields.includes("plan")) {
+			actions.updateField("unitPrice", PRICES[next.plan]);
+		}
+		// Recompute the total whenever quantity or unitPrice changes.
+		if (
+			changedFields.includes("quantity") ||
+			changedFields.includes("unitPrice")
+		) {
+			actions.updateField("total", next.quantity * next.unitPrice);
+		}
+		// Clear the dependent company name when the invoice flag turns off.
+		if (changedFields.includes("needsInvoice") && !next.needsInvoice) {
+			actions.updateField("companyName", "");
+		}
+
+		append({
+			changedFields,
+			text: `→ unitPrice=${next.unitPrice}, total=${next.total}, companyName="${next.companyName}"`,
+		});
+	},
+});
+</script>
+
+<template>
+	<div class="min-h-screen bg-gray-50 py-8 px-4">
+		<div class="max-w-5xl mx-auto">
+			<div class="mb-8">
+				<h1 class="text-3xl font-bold text-gray-900">Data Change</h1>
+				<p class="text-gray-600 mt-1">
+					Demonstrates <code>onDataChange</code> driving dependent-field
+					auto-fill, recomputation, and cleanup via <code>updateField</code>
+					(WIZ-010).
+				</p>
+			</div>
+
+			<div class="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-6">
+				<Card class="p-8">
+					<h2 class="text-xl font-semibold mb-4">
+						{{ state.currentStep.value?.meta?.title }}
+					</h2>
+
+					<div class="space-y-4">
+						<div class="space-y-3">
+							<label
+								v-for="p in (['basic', 'pro'] as const)"
+								:key="p"
+								:class="[
+									'flex items-center gap-3 rounded-lg border p-4 cursor-pointer transition',
+									state.data.value.plan === p
+										? 'border-blue-500 bg-blue-50'
+										: 'border-gray-200 hover:bg-gray-50',
+								]"
+							>
+								<input
+									type="radio"
+									name="plan"
+									:value="p"
+									:checked="state.data.value.plan === p"
+									class="accent-blue-600"
+									@change="actions.updateField('plan', p)"
+								/>
+								<div>
+									<div class="font-medium capitalize">{{ p }}</div>
+									<div class="text-xs text-gray-500">
+										${{ PRICES[p] }} / unit
+									</div>
+								</div>
+							</label>
+						</div>
+
+						<label class="block">
+							<span class="text-sm font-medium text-gray-700">Quantity</span>
+							<input
+								type="number"
+								min="1"
+								:value="state.data.value.quantity"
+								class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm"
+								@input="
+									actions.updateField(
+										'quantity',
+										Number(($event.target as HTMLInputElement).value) || 1,
+									)
+								"
+							/>
+						</label>
+
+						<div class="grid grid-cols-2 gap-4 text-sm">
+							<div>
+								<span class="text-gray-500">Unit price (auto-filled)</span>
+								<p class="font-mono font-medium">
+									${{ state.data.value.unitPrice }}
+								</p>
+							</div>
+							<div>
+								<span class="text-gray-500">Total (recomputed)</span>
+								<p class="font-mono font-medium">
+									${{ state.data.value.total }}
+								</p>
+							</div>
+						</div>
+
+						<label class="flex items-center gap-2 text-sm">
+							<input
+								type="checkbox"
+								:checked="state.data.value.needsInvoice"
+								class="accent-blue-600"
+								@change="
+									actions.updateField(
+										'needsInvoice',
+										($event.target as HTMLInputElement).checked,
+									)
+								"
+							/>
+							<span>I need an invoice</span>
+						</label>
+
+						<label class="block">
+							<span class="text-sm font-medium text-gray-700"
+								>Company name</span
+							>
+							<input
+								type="text"
+								:disabled="!state.data.value.needsInvoice"
+								:value="state.data.value.companyName"
+								class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm disabled:bg-gray-100 disabled:text-gray-400"
+								placeholder="Acme Inc."
+								@input="
+									actions.updateField(
+										'companyName',
+										($event.target as HTMLInputElement).value,
+									)
+								"
+							/>
+						</label>
+					</div>
+
+					<div class="flex flex-wrap gap-3 mt-8 pt-6 border-t">
+						<Button @click="actions.submit">Complete order</Button>
+					</div>
+
+					<p
+						v-if="state.isCompleted.value"
+						class="mt-4 text-sm text-emerald-700 font-medium"
+					>
+						✓ Order submitted.
+					</p>
+				</Card>
+
+				<Card class="p-5">
+					<h3 class="text-sm font-semibold text-gray-700 mb-3">
+						Data change log
+					</h3>
+					<p v-if="log.length === 0" class="text-xs text-gray-400 italic">
+						Edit a field to fire <code>onDataChange</code>
+					</p>
+					<ul v-else class="space-y-1.5">
+						<li
+							v-for="entry in [...log].reverse()"
+							:key="entry.id"
+							class="text-xs rounded-md border px-2 py-1.5 bg-blue-50 text-blue-700 border-blue-200"
+						>
+							<span class="font-mono font-semibold mr-2">{{
+								entry.changedFields.join(", ")
+							}}</span>
+							{{ entry.text }}
+						</li>
+					</ul>
+					<p class="mt-3 text-xs text-gray-400">
+						Changing <strong>plan</strong> auto-fills
+						<strong>unitPrice</strong>, which (with
+						<strong>quantity</strong>) recomputes <strong>total</strong>.
+						Unchecking <strong>needsInvoice</strong> clears
+						<strong>companyName</strong>. Each cascade step is its own
+						<code>onDataChange</code> round, and terminates via the
+						<code>Object.is</code> no-op guard on <code>updateField</code>.
+					</p>
+				</Card>
+			</div>
+		</div>
+	</div>
+</template>

--- a/packages/core/src/machine/wizard-machine.ts
+++ b/packages/core/src/machine/wizard-machine.ts
@@ -74,6 +74,13 @@ export interface WizardEvents<T> {
 	/** Fired after `reset()` (and after `cancel()`'s implicit reset). */
 	onReset?: () => void;
 	onError?: (error: Error) => void;
+	/**
+	 * Fired AFTER a data mutation (updateField / updateData / setData) that
+	 * actually changes at least one top-level field. NOT fired on reset(),
+	 * restore(), or navigation. `changedFields` are the top-level keys whose
+	 * value changed (Object.is comparison). See WIZ-010.
+	 */
+	onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
 }
 
 /**
@@ -149,6 +156,11 @@ export class WizardMachine<T extends WizardData> {
 	// WIZ-007: plugin host and the read-only facade passed to plugin hooks.
 	private pluginHost!: PluginHost<T>;
 	private readonlyFacade!: WizardMachineReadonly<T>;
+	/** WIZ-010: field-level subscribers keyed by field name. */
+	private fieldWatchers = new Map<
+		keyof T,
+		Set<(newValue: T[keyof T], oldValue: T[keyof T]) => void>
+	>();
 
 	/**
 	 * @param plugins Optional plugins to register at construction time.
@@ -432,6 +444,10 @@ export class WizardMachine<T extends WizardData> {
 	 * Updates wizard data
 	 */
 	updateData(updater: (data: T) => T): void {
+		// WIZ-010: shallow-copy the current top-level keys BEFORE running the
+		// updater. This survives an in-place-mutating updater (which would leave
+		// prevRef === newData) so the shallow diff is still correct.
+		const prevSnapshot = { ...this.state.data };
 		const newData = updater(this.state.data);
 		const newStatuses = this.recalculateSkippedStatuses();
 		this.state = {
@@ -440,24 +456,135 @@ export class WizardMachine<T extends WizardData> {
 			stepStatuses: newStatuses,
 		};
 		this.notifyStateChange();
+		const changedFields = this.diffChangedFields(prevSnapshot, newData);
+		this.emitDataChange(prevSnapshot, newData, changedFields);
+	}
+
+	/**
+	 * Updates a single top-level field. If the new value is Object.is-equal to the
+	 * current value this is a NO-OP: no state write, no onStateChange, no
+	 * onDataChange/watchers/plugin hook. Otherwise commits the change and fires
+	 * onDataChange (and watchers / plugin onDataChange) with changedFields = [field].
+	 * WIZ-010.
+	 */
+	updateField<K extends keyof T>(field: K, value: T[K]): void {
+		const prev = this.state.data;
+		if (Object.is(prev[field], value)) {
+			return; // no-op: identical value
+		}
+		const prevSnapshot = { ...prev };
+		const nextData = { ...prev, [field]: value };
+		const newStatuses = this.recalculateSkippedStatuses();
+		this.state = {
+			...this.state,
+			data: nextData,
+			stepStatuses: newStatuses,
+		};
+		this.notifyStateChange();
+		this.emitDataChange(prevSnapshot, nextData, [field]);
 	}
 
 	/**
 	 * Sets wizard data directly
 	 */
 	setData(data: T): void {
+		const prevSnapshot = { ...this.state.data };
 		const newStatuses = this.recalculateSkippedStatuses();
 		// FIX M-d: clone the caller's input (matching the constructor/reset/
 		// serialize contract) so a later external mutation of `data` cannot
 		// silently mutate `state.data` while bypassing notifyStateChange.
 		// `updateData`'s updater-return is a separate, documented in/out
 		// contract and is intentionally left as-is.
+		const cloned = this.cloneData(data);
 		this.state = {
 			...this.state,
-			data: this.cloneData(data),
+			data: cloned,
 			stepStatuses: newStatuses,
 		};
 		this.notifyStateChange();
+		const changedFields = this.diffChangedFields(prevSnapshot, cloned);
+		this.emitDataChange(prevSnapshot, cloned, changedFields);
+	}
+
+	/**
+	 * Subscribes to changes of a single top-level field. The callback fires only
+	 * when that field's value changes (Object.is) via updateField / updateData /
+	 * setData — NOT on reset(), restore(), or navigation. Returns an unsubscribe
+	 * function. A throwing callback is isolated: it is routed to onError (phase
+	 * "data") and does not prevent other watchers/plugins or corrupt the update.
+	 */
+	watchField<K extends keyof T>(
+		field: K,
+		callback: (newValue: T[K], oldValue: T[K]) => void,
+	): () => void {
+		let set = this.fieldWatchers.get(field);
+		if (!set) {
+			set = new Set();
+			this.fieldWatchers.set(field, set);
+		}
+		const cb = callback as (n: T[keyof T], o: T[keyof T]) => void;
+		set.add(cb);
+		return () => {
+			const s = this.fieldWatchers.get(field);
+			if (!s) return;
+			s.delete(cb);
+			if (s.size === 0) this.fieldWatchers.delete(field);
+		};
+	}
+
+	/** Shallow diff of top-level keys (Object.is). Returns changed keys. */
+	private diffChangedFields(prev: T, next: T): (keyof T)[] {
+		const keys = new Set<keyof T>([
+			...(Object.keys(prev) as (keyof T)[]),
+			...(Object.keys(next) as (keyof T)[]),
+		]);
+		const changed: (keyof T)[] = [];
+		for (const key of keys) {
+			if (!Object.is(prev[key], next[key])) changed.push(key);
+		}
+		return changed;
+	}
+
+	/**
+	 * WIZ-010: notifies data-change subscribers AFTER the state has been committed
+	 * and onStateChange has fired. No-op when nothing changed. All three subscriber
+	 * kinds are ISOLATED: a throw is routed to onError (phase "data") and never
+	 * prevents the others or corrupts the update.
+	 * Order: (1) events.onDataChange, (2) field watchers, (3) plugin onDataChange.
+	 */
+	private emitDataChange(prev: T, next: T, changedFields: (keyof T)[]): void {
+		if (changedFields.length === 0) return;
+
+		// (1) machine-level config callback — isolated for the new event.
+		if (this.events.onDataChange) {
+			try {
+				this.events.onDataChange(prev, next, changedFields);
+			} catch (err) {
+				this.handleError(err, "data");
+			}
+		}
+
+		// (2) field watchers — isolated per callback; snapshot the set so a
+		// callback that unsubscribes mid-iteration does not disturb the loop.
+		for (const field of changedFields) {
+			const set = this.fieldWatchers.get(field);
+			if (!set) continue;
+			for (const cb of [...set]) {
+				try {
+					cb(next[field], prev[field]);
+				} catch (err) {
+					this.handleError(err, "data");
+				}
+			}
+		}
+
+		// (3) plugin hook — isolated inside the host, fire-and-forget (like
+		// dispatchComplete/dispatchReset).
+		void this.pluginHost.dispatchDataChange(
+			prev as never,
+			next as never,
+			changedFields as never,
+		);
 	}
 
 	/**

--- a/packages/core/src/plugins/plugin-host.ts
+++ b/packages/core/src/plugins/plugin-host.ts
@@ -15,7 +15,7 @@ import type {
  */
 export type PluginErrorReporter = (
 	error: unknown,
-	phase?: "validation" | "transition" | "lifecycle" | "submit",
+	phase?: "validation" | "transition" | "lifecycle" | "submit" | "data",
 ) => void;
 
 /**
@@ -139,6 +139,20 @@ export class PluginHost<TData> {
 		}
 	}
 
+	/** Isolated onDataChange dispatch (fire-and-forget from the machine). */
+	async dispatchDataChange(
+		prev: DeepReadonly<TData>,
+		next: DeepReadonly<TData>,
+		changedFields: readonly (keyof TData)[],
+	): Promise<void> {
+		for (const plugin of this.plugins) {
+			await this.runIsolated(
+				() => plugin.onDataChange?.(prev, next, changedFields),
+				"data",
+			);
+		}
+	}
+
 	/**
 	 * Isolated onError dispatch. A throw INSIDE a plugin's onError is swallowed
 	 * (at most console.error) — never re-routed, to prevent infinite recursion.
@@ -179,7 +193,7 @@ export class PluginHost<TData> {
 	/** Awaits a hook, catching + reporting any throw/rejection. */
 	private async runIsolated(
 		fn: () => void | Promise<void>,
-		phase?: "validation" | "transition" | "lifecycle" | "submit",
+		phase?: "validation" | "transition" | "lifecycle" | "submit" | "data",
 	): Promise<void> {
 		try {
 			await fn();

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -28,7 +28,7 @@ export interface TransitionEvent<TData> {
 /** Context passed to a plugin's onError hook. */
 export interface ErrorContext<TData> {
 	stepId: StepId;
-	phase: "validation" | "transition" | "lifecycle" | "submit";
+	phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
 	data: DeepReadonly<TData>;
 }
 
@@ -41,8 +41,7 @@ export interface WizardMachineReadonly<TData> {
 
 /**
  * A runtime plugin registered on a WizardMachine. All hooks are optional
- * except `name` (unique; used by removePlugin). `onDataChange` is intentionally
- * omitted (deferred to WIZ-010).
+ * except `name` (unique; used by removePlugin).
  */
 export interface WizardPlugin<TData = unknown> {
 	name: string;
@@ -58,5 +57,16 @@ export interface WizardPlugin<TData = unknown> {
 	): void | Promise<void>;
 	onComplete?(data: DeepReadonly<TData>): void | Promise<void>;
 	onReset?(): void | Promise<void>;
+	/**
+	 * Fired after a data mutation that changed at least one top-level field.
+	 * Fire-and-forget: may be async (void | Promise<void>); the data update is
+	 * synchronous and does NOT await this hook. A throw/rejection is isolated
+	 * and routed to onError (phase "data"). Data params are DeepReadonly. WIZ-010.
+	 */
+	onDataChange?(
+		prevData: DeepReadonly<TData>,
+		nextData: DeepReadonly<TData>,
+		changedFields: readonly (keyof TData)[],
+	): void | Promise<void>;
 	destroy?(): void | Promise<void>;
 }

--- a/packages/core/tests/data-change.test.ts
+++ b/packages/core/tests/data-change.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it, vi } from "vitest";
+import { WizardMachine } from "../src/machine/wizard-machine";
+import type { WizardPlugin } from "../src/plugins/types";
+import { createSimpleLinearDefinition, type SimpleData } from "./fixtures";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const initial: SimpleData = { name: "a", email: "a@x.io" };
+
+function makeMachine(
+	events?: ConstructorParameters<typeof WizardMachine<SimpleData>>[3],
+	plugins?: WizardPlugin<SimpleData>[],
+): WizardMachine<SimpleData> {
+	return new WizardMachine<SimpleData>(
+		createSimpleLinearDefinition(),
+		{},
+		initial,
+		events,
+		plugins,
+	);
+}
+
+describe("onDataChange — updateField", () => {
+	it("fires onDataChange(prev, next, [field]) exactly once", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.updateField("name", "b");
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const [prev, next, changedFields] = onDataChange.mock.calls[0];
+		expect(prev.name).toBe("a");
+		expect(next.name).toBe("b");
+		expect(changedFields).toEqual(["name"]);
+	});
+
+	it("passes distinct prev/next objects reflecting old and new values", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.updateField("email", "b@x.io");
+		const [prev, next] = onDataChange.mock.calls[0];
+		expect(prev).not.toBe(next);
+		expect(prev.email).toBe("a@x.io");
+		expect(next.email).toBe("b@x.io");
+	});
+});
+
+describe("onDataChange — updateData shallow diff", () => {
+	it("reports every changed top-level key", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.updateData((d) => ({ ...d, name: "x", email: "y@z.io" }));
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const changedFields = onDataChange.mock.calls[0][2] as (keyof SimpleData)[];
+		expect(changedFields).toHaveLength(2);
+		expect(changedFields).toEqual(expect.arrayContaining(["name", "email"]));
+	});
+
+	it("reports only the single changed key", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.updateData((d) => ({ ...d, name: "x" }));
+		expect(onDataChange.mock.calls[0][2]).toEqual(["name"]);
+	});
+
+	it("diffs correctly for an in-place-mutating updater (prev snapshot captured first)", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.updateData((d) => {
+			d.name = "x";
+			return d;
+		});
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const [prev, , changedFields] = onDataChange.mock.calls[0];
+		expect(changedFields).toEqual(["name"]);
+		expect(prev.name).toBe("a");
+	});
+});
+
+describe("onDataChange — setData shallow diff", () => {
+	it("reports only the changed key", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.setData({ name: "x", email: initial.email });
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		expect(onDataChange.mock.calls[0][2]).toEqual(["name"]);
+	});
+});
+
+describe("onDataChange — no-op updates fire nothing", () => {
+	it("updateField to the current value fires nothing (not even onStateChange)", () => {
+		const onDataChange = vi.fn();
+		const onStateChange = vi.fn();
+		const watcher = vi.fn();
+		const plugin = vi.fn();
+		const m = makeMachine({ onDataChange, onStateChange }, [
+			{ name: "p", onDataChange: plugin },
+		]);
+		m.watchField("name", watcher);
+		onStateChange.mockClear();
+		m.updateField("name", initial.name);
+		expect(onDataChange).not.toHaveBeenCalled();
+		expect(watcher).not.toHaveBeenCalled();
+		expect(plugin).not.toHaveBeenCalled();
+		expect(onStateChange).not.toHaveBeenCalled();
+	});
+
+	it("updateData returning a new object with identical values fires onStateChange but not onDataChange", () => {
+		const onDataChange = vi.fn();
+		const onStateChange = vi.fn();
+		const m = makeMachine({ onDataChange, onStateChange });
+		onStateChange.mockClear();
+		m.updateData((d) => ({ ...d }));
+		expect(onStateChange).toHaveBeenCalledTimes(1);
+		expect(onDataChange).not.toHaveBeenCalled();
+	});
+
+	it("setData with identical values does not fire onDataChange", () => {
+		const onDataChange = vi.fn();
+		const m = makeMachine({ onDataChange });
+		m.setData({ ...initial });
+		expect(onDataChange).not.toHaveBeenCalled();
+	});
+});
+
+describe("watchField", () => {
+	it("fires cb(newValue, oldValue) for the watched field", () => {
+		const cb = vi.fn();
+		const m = makeMachine();
+		m.watchField("name", cb);
+		m.updateField("name", "x");
+		expect(cb).toHaveBeenCalledTimes(1);
+		expect(cb).toHaveBeenCalledWith("x", "a");
+	});
+
+	it("does not fire when a different field changes", () => {
+		const cb = vi.fn();
+		const m = makeMachine();
+		m.watchField("name", cb);
+		m.updateField("email", "b@x.io");
+		expect(cb).not.toHaveBeenCalled();
+	});
+
+	it("fires from updateData when the watched field changes", () => {
+		const cb = vi.fn();
+		const m = makeMachine();
+		m.watchField("name", cb);
+		m.updateData((d) => ({ ...d, name: "x" }));
+		expect(cb).toHaveBeenCalledWith("x", "a");
+	});
+
+	it("fires both watchers registered on the same field", () => {
+		const cb1 = vi.fn();
+		const cb2 = vi.fn();
+		const m = makeMachine();
+		m.watchField("name", cb1);
+		m.watchField("name", cb2);
+		m.updateField("name", "x");
+		expect(cb1).toHaveBeenCalledTimes(1);
+		expect(cb2).toHaveBeenCalledTimes(1);
+	});
+
+	it("unsubscribe removes the watcher; re-subscribing works; double-unsubscribe is safe", () => {
+		const cb = vi.fn();
+		const m = makeMachine();
+		const unsubscribe = m.watchField("name", cb);
+		unsubscribe();
+		m.updateField("name", "x");
+		expect(cb).not.toHaveBeenCalled();
+
+		// Re-subscribe works.
+		m.watchField("name", cb);
+		m.updateField("name", "y");
+		expect(cb).toHaveBeenCalledTimes(1);
+
+		// Unsubscribing twice is safe (no throw).
+		expect(() => {
+			unsubscribe();
+			unsubscribe();
+		}).not.toThrow();
+	});
+});
+
+describe("onDataChange — ordering", () => {
+	it("fires onStateChange before onDataChange before the field watcher", () => {
+		const order: string[] = [];
+		const m = makeMachine({
+			onStateChange: () => order.push("state"),
+			onDataChange: () => order.push("data"),
+		});
+		m.watchField("name", () => order.push("watcher"));
+		order.length = 0; // drop the construction-time onStateChange
+		m.updateField("name", "x");
+		expect(order).toEqual(["state", "data", "watcher"]);
+	});
+});
+
+describe("onDataChange — error isolation", () => {
+	it("a throwing onDataChange routes to onError, does not block the watcher, and does not throw", () => {
+		const boom = new Error("event boom");
+		const onError = vi.fn();
+		const watcher = vi.fn();
+		const m = makeMachine({
+			onError,
+			onDataChange: () => {
+				throw boom;
+			},
+		});
+		m.watchField("name", watcher);
+		expect(() => m.updateField("name", "x")).not.toThrow();
+		expect(onError).toHaveBeenCalledWith(boom);
+		expect(watcher).toHaveBeenCalledTimes(1);
+		expect(m.snapshot.data.name).toBe("x");
+	});
+
+	it("a throwing watcher routes to onError, does not block a second watcher, and does not throw", () => {
+		const boom = new Error("watcher boom");
+		const onError = vi.fn();
+		const second = vi.fn();
+		const m = makeMachine({ onError });
+		m.watchField("name", () => {
+			throw boom;
+		});
+		m.watchField("name", second);
+		expect(() => m.updateField("name", "x")).not.toThrow();
+		expect(onError).toHaveBeenCalledWith(boom);
+		expect(second).toHaveBeenCalledTimes(1);
+		expect(m.snapshot.data.name).toBe("x");
+	});
+
+	it("routes onDataChange throws with phase 'data' to plugin onError", async () => {
+		const boom = new Error("event boom");
+		const onError = vi.fn();
+		const m = makeMachine(
+			{
+				onDataChange: () => {
+					throw boom;
+				},
+			},
+			[{ name: "p", onError }],
+		);
+		m.updateField("name", "x");
+		await flush();
+		expect(onError).toHaveBeenCalledTimes(1);
+		const [err, ctx] = onError.mock.calls[0];
+		expect(err).toBe(boom);
+		expect(ctx).toMatchObject({ phase: "data" });
+	});
+});
+
+describe("onDataChange — reset() / restore() silence", () => {
+	it("reset() does not fire onDataChange / watchers / plugin onDataChange (still fires onReset)", async () => {
+		const onDataChange = vi.fn();
+		const onReset = vi.fn();
+		const watcher = vi.fn();
+		const pluginDataChange = vi.fn();
+		const m = makeMachine({ onDataChange, onReset }, [
+			{ name: "p", onDataChange: pluginDataChange },
+		]);
+		m.watchField("name", watcher);
+		m.updateField("name", "changed");
+		onDataChange.mockClear();
+		watcher.mockClear();
+		pluginDataChange.mockClear();
+
+		m.reset();
+		await flush();
+		expect(onReset).toHaveBeenCalledTimes(1);
+		expect(onDataChange).not.toHaveBeenCalled();
+		expect(watcher).not.toHaveBeenCalled();
+		expect(pluginDataChange).not.toHaveBeenCalled();
+	});
+
+	it("restore() does not fire onDataChange / watchers / plugin onDataChange", async () => {
+		const onDataChange = vi.fn();
+		const watcher = vi.fn();
+		const pluginDataChange = vi.fn();
+		const source = makeMachine();
+		source.updateField("name", "restored");
+		const serialized = source.serialize();
+
+		const m = makeMachine({ onDataChange }, [
+			{ name: "p", onDataChange: pluginDataChange },
+		]);
+		m.watchField("name", watcher);
+		m.restore(serialized);
+		await flush();
+		expect(onDataChange).not.toHaveBeenCalled();
+		expect(watcher).not.toHaveBeenCalled();
+		expect(pluginDataChange).not.toHaveBeenCalled();
+	});
+});

--- a/packages/core/tests/fixtures.ts
+++ b/packages/core/tests/fixtures.ts
@@ -108,5 +108,6 @@ export function createEventSpies<T extends Record<string, unknown>>(): Required<
 		onCancel: vi.fn(),
 		onReset: vi.fn(),
 		onError: vi.fn(),
+		onDataChange: vi.fn(),
 	};
 }

--- a/packages/core/tests/plugins.test.ts
+++ b/packages/core/tests/plugins.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, expectTypeOf, it, test, vi } from "vitest";
 import type { WizardError } from "../src/errors";
 import { WizardConfigurationError, WizardValidationError } from "../src/errors";
+import type { WizardEvents } from "../src/machine/wizard-machine";
 import { WizardMachine } from "../src/machine/wizard-machine";
 import type {
 	DeepReadonly,
@@ -48,7 +49,7 @@ describe("plugin types", () => {
 
 	test("ErrorContext phase is a fixed union", () => {
 		expectTypeOf<ErrorContext<Data>["phase"]>().toEqualTypeOf<
-			"validation" | "transition" | "lifecycle" | "submit"
+			"validation" | "transition" | "lifecycle" | "submit" | "data"
 		>();
 	});
 
@@ -69,10 +70,22 @@ describe("plugin types", () => {
 		expectTypeOf(veto).not.toBeUndefined();
 	});
 
-	test("WizardPlugin does NOT include onDataChange (deferred to WIZ-010)", () => {
-		// @ts-expect-error onDataChange is intentionally not part of the interface
-		const _p: WizardPlugin<Data> = { name: "x", onDataChange: () => {} };
-		void _p;
+	test("WizardPlugin accepts an onDataChange hook with DeepReadonly payloads (WIZ-010)", () => {
+		const p: WizardPlugin<Data> = {
+			name: "x",
+			onDataChange: (prev, next, changedFields) => {
+				expectTypeOf(prev).toEqualTypeOf<DeepReadonly<Data>>();
+				expectTypeOf(next).toEqualTypeOf<DeepReadonly<Data>>();
+				expectTypeOf(changedFields).toEqualTypeOf<readonly (keyof Data)[]>();
+			},
+		};
+		expectTypeOf(p.onDataChange).returns.toEqualTypeOf<void | Promise<void>>();
+	});
+
+	test("WizardEvents onDataChange uses plain T params (WIZ-010)", () => {
+		expectTypeOf<
+			NonNullable<WizardEvents<Data>["onDataChange"]>
+		>().parameters.toEqualTypeOf<[Data, Data, (keyof Data)[]]>();
 	});
 });
 
@@ -729,5 +742,119 @@ describe("WizardMachine onComplete / onReset boundaries", () => {
 		const [err, ctx] = onError.mock.calls[0];
 		expect(err).toBe(boom);
 		expect(ctx).toMatchObject({ phase: "lifecycle" });
+	});
+});
+
+describe("WizardMachine onDataChange plugin hook (WIZ-010)", () => {
+	it("fires a plugin's onDataChange after updateField with (prev, next, changedFields)", async () => {
+		const onDataChange = vi.fn();
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[{ name: "p", onDataChange }],
+		);
+		m.updateField("name", "b");
+		await flush();
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const [prev, next, changedFields] = onDataChange.mock.calls[0];
+		expect(prev.name).toBe("a");
+		expect(next.name).toBe("b");
+		expect(changedFields).toEqual(["name"]);
+	});
+
+	it("fires a plugin's onDataChange after updateData with the shallow diff", async () => {
+		const onDataChange = vi.fn();
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[{ name: "p", onDataChange }],
+		);
+		m.updateData((d) => ({ ...d, name: "b" }));
+		await flush();
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		expect(onDataChange.mock.calls[0][2]).toEqual(["name"]);
+	});
+
+	it("isolates a rejected async plugin onDataChange and routes it to onError (phase 'data')", async () => {
+		const boom = new Error("async boom");
+		const onError = vi.fn();
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[
+				{
+					name: "p",
+					onDataChange: async () => {
+						throw boom;
+					},
+					onError,
+				},
+			],
+		);
+		m.updateField("name", "b");
+		await flush();
+		expect(m.snapshot.data.name).toBe("b");
+		expect(onError).toHaveBeenCalledTimes(1);
+		const [err, ctx] = onError.mock.calls[0];
+		expect(err).toBe(boom);
+		expect(ctx).toMatchObject({ phase: "data" });
+	});
+
+	it("a throwing plugin onDataChange does not prevent other plugins and routes to every onError", async () => {
+		const boom = new Error("sync boom");
+		const onErrorA = vi.fn();
+		const onDataChangeB = vi.fn();
+		const onErrorB = vi.fn();
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[
+				{
+					name: "a",
+					onDataChange: () => {
+						throw boom;
+					},
+					onError: onErrorA,
+				},
+				{ name: "b", onDataChange: onDataChangeB, onError: onErrorB },
+			],
+		);
+		m.updateField("name", "b");
+		await flush();
+		expect(onDataChangeB).toHaveBeenCalledTimes(1);
+		expect(onErrorA).toHaveBeenCalledWith(
+			boom,
+			expect.objectContaining({ phase: "data" }),
+		);
+		expect(onErrorB).toHaveBeenCalledWith(
+			boom,
+			expect.objectContaining({ phase: "data" }),
+		);
+		expect(m.snapshot.data.name).toBe("b");
+	});
+
+	it("plugins registered via constructor AND via use() both receive onDataChange", async () => {
+		const ctorHook = vi.fn();
+		const lateHook = vi.fn();
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[{ name: "ctor", onDataChange: ctorHook }],
+		);
+		m.use({ name: "late", onDataChange: lateHook });
+		m.updateField("name", "b");
+		await flush();
+		expect(ctorHook).toHaveBeenCalledTimes(1);
+		expect(lateHook).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/docs/guide/api/core.md
+++ b/packages/docs/guide/api/core.md
@@ -441,6 +441,10 @@ class WizardMachine<T> {
   // Data operations
   updateData(updater: (data: T) => T): void;
   setData(data: T): void;
+  /** Update one top-level field. Object.is no-op guard. Fires onDataChange with changedFields=[field]. (WIZ-010) */
+  updateField<K extends keyof T>(field: K, value: T[K]): void;
+  /** Subscribe to one field. Returns an unsubscribe function. (WIZ-010) */
+  watchField<K extends keyof T>(field: K, callback: (newValue: T[K], oldValue: T[K]) => void): () => void;
 
   // Validation & submission
   validate(): Promise<ValidationResult>;
@@ -510,6 +514,17 @@ interface WizardEvents<T> {
   /** Fired after `reset()` (and after `cancel()`'s implicit reset). */
   onReset?: () => void;
   onError?: (error: Error) => void;
+  /**
+   * Fired after a data mutation (updateField/updateData/setData) that changes
+   * at least one top-level field. Fires after onStateChange; NOT fired on
+   * reset(), restore(), or navigation. changedFields are the changed top-level
+   * keys (Object.is). (WIZ-010)
+   */
+  onDataChange?: (
+    prevData: T,
+    nextData: T,
+    changedFields: (keyof T)[],
+  ) => void;
 }
 ```
 
@@ -858,6 +873,15 @@ machine.updateData((d) => ({ ...d, name: "John" }));
 // Replace all data
 machine.setData({ name: "Jane", email: "jane@example.com" });
 
+// Update one field (no-op if the value is Object.is-equal to the current value)
+machine.updateField("name", "John");
+
+// React to data changes (fires after onStateChange; not on reset/restore/navigation)
+const stop = machine.watchField("name", (next, prev) => {
+  console.log(`name: ${prev} → ${next}`);
+});
+stop(); // unsubscribe
+
 // Validate
 const result = await machine.validate();
 if (result.valid) {
@@ -926,6 +950,12 @@ interface WizardPlugin<TData = unknown> {
   ): void | Promise<void>;
   onComplete?(data: DeepReadonly<TData>): void | Promise<void>;
   onReset?(): void | Promise<void>;
+  /** Fired after a data mutation that changed ≥1 top-level field. Fire-and-forget; DeepReadonly payloads; errors routed to onError phase "data". (WIZ-010) */
+  onDataChange?(
+    prevData: DeepReadonly<TData>,
+    nextData: DeepReadonly<TData>,
+    changedFields: readonly (keyof TData)[],
+  ): void | Promise<void>;
   destroy?(): void | Promise<void>;
 }
 ```
@@ -951,7 +981,7 @@ Context passed to `onError`.
 ```ts
 interface ErrorContext<TData> {
   stepId: StepId;
-  phase: "validation" | "transition" | "lifecycle" | "submit";
+  phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
   data: DeepReadonly<TData>;
 }
 ```

--- a/packages/docs/guide/api/react.md
+++ b/packages/docs/guide/api/react.md
@@ -27,6 +27,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /**
    * Plugins registered once at machine creation (reference-stable — read once,
    * NOT reactive). Define them outside render or memoize them.
@@ -168,6 +169,7 @@ interface WizardProviderProps<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
   children: React.ReactNode;

--- a/packages/docs/guide/api/vue.md
+++ b/packages/docs/guide/api/vue.md
@@ -27,6 +27,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /**
    * Plugins registered once at machine creation (reference-stable — read once,
    * NOT reactive). Define them outside setup or hoist them.

--- a/packages/docs/guide/core-concepts.md
+++ b/packages/docs/guide/core-concepts.md
@@ -373,6 +373,11 @@ interface WizardEvents<T> {
   onSubmit?: (stepId: string, data: T) => void;
   onComplete?: (data: T) => void;
   onError?: (error: Error) => void;
+  onDataChange?: (
+    prevData: T,
+    nextData: T,
+    changedFields: (keyof T)[],
+  ) => void;
 }
 ```
 
@@ -389,6 +394,30 @@ const machine = new WizardMachine(definition, context, initialData, {
     showErrorMessage(error.message);
   },
 });
+```
+
+### Reacting to data changes
+
+`onDataChange` fires after any data mutation (`updateField`, `updateData`, or `setData`) that actually changes at least one top-level field, with the previous data, the next data, and the list of changed keys. It fires **after** `onStateChange`, and is **not** fired by `reset()`, `restore()`, or navigation. A no-op update (setting a field to its current value) fires nothing.
+
+```typescript
+const machine = new WizardMachine(definition, context, initialData, {
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      // Recompute a dependent field when the plan changes.
+      machine.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+```
+
+For a single field, `watchField` subscribes to just that key and returns an unsubscribe function (core-only; not exposed through the React/Vue hooks):
+
+```typescript
+const stop = machine.watchField("email", (newEmail, oldEmail) => {
+  console.log(`email changed: ${oldEmail} → ${newEmail}`);
+});
+// later: stop();
 ```
 
 ## 10. Type Safety

--- a/packages/docs/guide/plugins.md
+++ b/packages/docs/guide/plugins.md
@@ -7,7 +7,7 @@ description: Intercept wizard transitions and lifecycle events globally with the
 
 Plugins let you intercept wizard transitions and lifecycle events globally, across every step — ideal for analytics, logging, error reporting, and auto-save. A plugin is a plain object implementing the `WizardPlugin` interface; you register instances on the machine.
 
-> `onDataChange` is **not** part of the plugin interface yet — it is deferred to WIZ-010 and will be added as a non-breaking extension.
+> `onDataChange(prevData, nextData, changedFields)` is part of the plugin interface (WIZ-010). It fires after any data mutation (`updateField` / `updateData` / `setData`) that changes at least one top-level field, with `DeepReadonly` data payloads. It is fire-and-forget (may be async) and isolated — a throw or rejection is routed to `onError` with `phase: "data"`.
 
 ## The `WizardPlugin` Interface
 
@@ -35,6 +35,13 @@ interface WizardPlugin<TData = unknown> {
 
   onReset?(): void | Promise<void>;
 
+  /** Fired after a data mutation that changed at least one top-level field. */
+  onDataChange?(
+    prevData: DeepReadonly<TData>,
+    nextData: DeepReadonly<TData>,
+    changedFields: readonly (keyof TData)[],
+  ): void | Promise<void>;
+
   destroy?(): void | Promise<void>;
 }
 ```
@@ -56,7 +63,7 @@ interface TransitionEvent<TData> {
 /** Context passed to a plugin's onError hook. */
 interface ErrorContext<TData> {
   stepId: StepId;
-  phase: "validation" | "transition" | "lifecycle" | "submit";
+  phase: "validation" | "transition" | "lifecycle" | "submit" | "data";
   data: DeepReadonly<TData>;
 }
 

--- a/packages/docs/guide/react-integration.md
+++ b/packages/docs/guide/react-integration.md
@@ -121,6 +121,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
 }
@@ -187,7 +188,23 @@ loading.isNavigating; // Navigation in progress?
 actions.updateData((data) => ({ ...data, name: "John" }));
 actions.setData(completeData);
 actions.updateField("name", "John");
+```
 
+React to data changes by passing `onDataChange` to `useWizard`. It fires after any `updateField` / `updateData` / `setData` that changes a top-level field (after `onStateChange`; not on reset/restore/navigation):
+
+```tsx
+const { actions } = useWizard({
+  definition,
+  initialData,
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      actions.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+```
+
+```typescript
 // Validation
 actions.validate(); // Manually validate (result goes to validation slice)
 actions.validateAll(); // Dry-run all enabled steps → ValidationSummary

--- a/packages/docs/guide/vue-integration.md
+++ b/packages/docs/guide/vue-integration.md
@@ -166,6 +166,7 @@ interface UseWizardOptions<T> {
   onCancel?: (data: T) => void | Promise<void>;
   onReset?: () => void;
   onError?: (error: Error) => void;
+  onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
   /** Reference-stable — read once at machine creation. */
   plugins?: WizardPlugin<T>[];
 }
@@ -232,7 +233,25 @@ loading.isNavigating.value; // Navigation in progress? (ComputedRef)
 actions.updateData((data) => ({ ...data, name: "John" }));
 actions.setData(completeData);
 actions.updateField("name", "John");
+```
 
+React to data changes by passing `onDataChange` to `useWizard`. It fires after any `updateField` / `updateData` / `setData` that changes a top-level field (after `onStateChange`; not on reset/restore/navigation):
+
+```vue
+<script setup lang="ts">
+const { actions } = useWizard({
+  definition,
+  initialData,
+  onDataChange: (prev, next, changedFields) => {
+    if (changedFields.includes("plan")) {
+      actions.updateField("price", PRICES[next.plan]);
+    }
+  },
+});
+</script>
+```
+
+```typescript
 // Validation
 await actions.validate(); // Manually validate (result goes to validation slice)
 await actions.validateAll(); // Dry-run all enabled steps → ValidationSummary

--- a/packages/react/src/use-wizard.tsx
+++ b/packages/react/src/use-wizard.tsx
@@ -52,6 +52,7 @@ export interface UseWizardOptions<T extends WizardData> {
 	onCancel?: (data: T) => void | Promise<void>;
 	onReset?: () => void;
 	onError?: (error: Error) => void;
+	onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
 	/**
 	 * Plugins registered once at machine creation (reference-stable — read once,
 	 * NOT reactive). Define them outside render or memoize them.
@@ -195,6 +196,7 @@ export function useWizard<T extends WizardData>(
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 		plugins,
 	} = options;
 
@@ -207,6 +209,7 @@ export function useWizard<T extends WizardData>(
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 	});
 
 	// Update callbacks ref synchronously
@@ -218,6 +221,7 @@ export function useWizard<T extends WizardData>(
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 	};
 
 	// Store initial data, context, and definition in refs for stable references
@@ -261,6 +265,9 @@ export function useWizard<T extends WizardData>(
 			},
 			onError: (error: Error) => {
 				callbacksRef.current.onError?.(error);
+			},
+			onDataChange: (prev: T, next: T, changedFields: (keyof T)[]) => {
+				callbacksRef.current.onDataChange?.(prev, next, changedFields);
 			},
 		}),
 		[],
@@ -376,12 +383,9 @@ export function useWizard<T extends WizardData>(
 
 	const updateField = useCallback(
 		<K extends keyof T>(field: K, value: T[K]) => {
-			updateData((data: T) => ({
-				...data,
-				[field]: value,
-			}));
+			manager.getMachine().updateField(field, value);
 		},
-		[updateData],
+		[manager],
 	);
 
 	// Validation

--- a/packages/react/src/wizard-provider.tsx
+++ b/packages/react/src/wizard-provider.tsx
@@ -59,6 +59,7 @@ export interface WizardProviderProps<T extends WizardData> {
 	onCancel?: (data: T) => void | Promise<void>;
 	onReset?: () => void;
 	onError?: (error: Error) => void;
+	onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
 	/**
 	 * Plugins registered once at machine creation (reference-stable — read once,
 	 * NOT reactive). Define them outside render or memoize them.
@@ -86,6 +87,7 @@ export function WizardProvider<T extends WizardData>({
 	onCancel,
 	onReset,
 	onError,
+	onDataChange,
 	plugins,
 	children,
 }: WizardProviderProps<T>) {
@@ -98,6 +100,7 @@ export function WizardProvider<T extends WizardData>({
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 	});
 
 	// Update callbacks ref synchronously
@@ -109,6 +112,7 @@ export function WizardProvider<T extends WizardData>({
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 	};
 
 	// Store initial values in refs
@@ -156,6 +160,9 @@ export function WizardProvider<T extends WizardData>({
 			},
 			onError: (error: Error) => {
 				callbacksRef.current.onError?.(error);
+			},
+			onDataChange: (prev: T, next: T, changedFields: (keyof T)[]) => {
+				callbacksRef.current.onDataChange?.(prev, next, changedFields);
 			},
 		};
 

--- a/packages/react/tests/use-wizard-data-change.test.tsx
+++ b/packages/react/tests/use-wizard-data-change.test.tsx
@@ -1,0 +1,51 @@
+import { createLinearWizard } from "@gooonzick/wizard-core";
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useWizard } from "../src/use-wizard";
+
+describe("useWizard onDataChange option (WIZ-010)", () => {
+	const makeDefinition = () =>
+		createLinearWizard<{ name: string; email: string }>({
+			id: "data-change-wizard",
+			steps: [{ id: "step1", title: "Step 1" }],
+		});
+
+	it("invokes onDataChange when updateField mutates a field", async () => {
+		const onDataChange = vi.fn();
+		const { result } = renderHook(() =>
+			useWizard({
+				definition: makeDefinition(),
+				initialData: { name: "a", email: "a@x.io" },
+				onDataChange,
+			}),
+		);
+
+		await act(async () => {
+			result.current.actions.updateField("name", "b");
+		});
+
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const [prev, next, changedFields] = onDataChange.mock.calls[0];
+		expect(prev.name).toBe("a");
+		expect(next.name).toBe("b");
+		expect(changedFields).toEqual(["name"]);
+	});
+
+	it("invokes onDataChange when updateData mutates data", async () => {
+		const onDataChange = vi.fn();
+		const { result } = renderHook(() =>
+			useWizard({
+				definition: makeDefinition(),
+				initialData: { name: "a", email: "a@x.io" },
+				onDataChange,
+			}),
+		);
+
+		await act(async () => {
+			result.current.actions.updateData((d) => ({ ...d, email: "b@x.io" }));
+		});
+
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		expect(onDataChange.mock.calls[0][2]).toEqual(["email"]);
+	});
+});

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -56,6 +56,7 @@ export interface UseWizardOptions<T extends WizardData> {
 	onCancel?: (data: T) => void | Promise<void>;
 	onReset?: () => void;
 	onError?: (error: Error) => void;
+	onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
 	/**
 	 * Plugins registered once at machine creation (reference-stable — read once,
 	 * NOT reactive). Define them outside setup or hoist them.

--- a/packages/vue/src/use-wizard.ts
+++ b/packages/vue/src/use-wizard.ts
@@ -43,6 +43,7 @@ export function useWizard<T extends WizardData>(
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 		plugins,
 	} = options;
 
@@ -55,6 +56,7 @@ export function useWizard<T extends WizardData>(
 		onCancel,
 		onReset,
 		onError,
+		onDataChange,
 	};
 
 	// Forward reference for state - needed for createMachine callback
@@ -104,6 +106,9 @@ export function useWizard<T extends WizardData>(
 				},
 				onError: (error: Error) => {
 					callbacks.onError?.(error);
+				},
+				onDataChange: (prev: T, next: T, changedFields: (keyof T)[]) => {
+					callbacks.onDataChange?.(prev, next, changedFields);
 				},
 			},
 			plugins,
@@ -222,11 +227,8 @@ export function useWizard<T extends WizardData>(
 	};
 
 	const updateField = <K extends keyof T>(field: K, value: T[K]) => {
-		updateData((data: T) => ({
-			...data,
-			[field]: value,
-		}));
-		// updateNavigationState() is already called in updateData
+		machine.value.updateField(field, value);
+		updateNavigationState();
 	};
 
 	// Validation

--- a/packages/vue/src/wizard-provider.ts
+++ b/packages/vue/src/wizard-provider.ts
@@ -65,6 +65,7 @@ export interface WizardProviderProps<T extends WizardData> {
 	onCancel?: (data: T) => void | Promise<void>;
 	onReset?: () => void;
 	onError?: (error: Error) => void;
+	onDataChange?: (prevData: T, nextData: T, changedFields: (keyof T)[]) => void;
 	plugins?: WizardPlugin<T>[];
 }
 
@@ -103,6 +104,11 @@ export const WizardProvider = defineComponent({
 		) => void | Promise<void>,
 		onReset: Function as unknown as () => () => void,
 		onError: Function as unknown as () => (error: Error) => void,
+		onDataChange: Function as unknown as () => (
+			prevData: WizardData,
+			nextData: WizardData,
+			changedFields: (keyof WizardData)[],
+		) => void,
 		plugins: Array as unknown as () => WizardPlugin<WizardData>[],
 	},
 	setup(props, { slots }) {
@@ -119,6 +125,7 @@ export const WizardProvider = defineComponent({
 			onCancel: props.onCancel,
 			onReset: props.onReset,
 			onError: props.onError,
+			onDataChange: props.onDataChange,
 			plugins: props.plugins,
 		});
 

--- a/packages/vue/tests/use-wizard-data-change.test.ts
+++ b/packages/vue/tests/use-wizard-data-change.test.ts
@@ -1,0 +1,55 @@
+import { createLinearWizard } from "@gooonzick/wizard-core";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import type { UseWizardReturn } from "../src/types";
+import { useWizard } from "../src/use-wizard";
+
+type Data = { name: string; email: string };
+
+function mountWizard(onDataChange: (...args: unknown[]) => void) {
+	let wizardRef!: UseWizardReturn<Data>;
+	const definition = createLinearWizard<Data>({
+		id: "data-change-wizard",
+		steps: [{ id: "step1", title: "Step 1" }],
+	});
+	const TestComponent = defineComponent({
+		setup() {
+			const wizard = useWizard({
+				definition,
+				initialData: { name: "a", email: "a@x.io" },
+				onDataChange,
+			});
+			wizardRef = wizard;
+			return { wizard };
+		},
+		template: "<div></div>",
+	});
+	mount(TestComponent);
+	return wizardRef;
+}
+
+describe("useWizard onDataChange option (WIZ-010)", () => {
+	it("invokes onDataChange when updateField mutates a field", () => {
+		const onDataChange = vi.fn();
+		const wizard = mountWizard(onDataChange);
+
+		wizard.actions.updateField("name", "b");
+
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		const [prev, next, changedFields] = onDataChange.mock.calls[0];
+		expect(prev.name).toBe("a");
+		expect(next.name).toBe("b");
+		expect(changedFields).toEqual(["name"]);
+	});
+
+	it("invokes onDataChange when updateData mutates data", () => {
+		const onDataChange = vi.fn();
+		const wizard = mountWizard(onDataChange);
+
+		wizard.actions.updateData((d) => ({ ...d, email: "b@x.io" }));
+
+		expect(onDataChange).toHaveBeenCalledTimes(1);
+		expect(onDataChange.mock.calls[0][2]).toEqual(["email"]);
+	});
+});


### PR DESCRIPTION
## Summary

Implements **WIZ-010** from the roadmap, plus docs/examples/skill updates. Also merges in `chore/roadmap-update` (roadmap reconciliation, WIZ-009 dropped, normalized statuses).

### Core (`@gooonzick/wizard-core`)
- `onDataChange?: (prevData, nextData, changedFields) => void` on `WizardEvents<T>` — fires after a data mutation (`updateField` / `updateData` / `setData`) that changes at least one top-level field (Object.is shallow diff). **Not** fired on `reset()` / `restore()` / navigation, nor on no-op updates.
- New `WizardMachine.updateField(field, value)` core method with an Object.is no-op guard.
- `WizardMachine.watchField(field, cb)` — field-level subscription returning an unsubscribe fn (core-only).
- `WizardPlugin.onDataChange` hook (DeepReadonly payloads, fire-and-forget) + new `"data"` phase in `ErrorContext` — the piece deliberately deferred from WIZ-007.
- Prev-data snapshot is captured **before** the updater runs, so in-place-mutating updaters still diff correctly.
- All subscriber kinds (event, watchers, plugin hook) are error-isolated: a throwing callback routes to `onError` (phase `"data"`) without breaking the update or other subscribers.
- Order: state commit → `onStateChange` → `onDataChange` → field watchers → plugin hook.

### Integrations
- react/vue: `onDataChange` option on `useWizard` and providers; framework `updateField` now delegates to the core method.

### Docs, examples, skill
- Both doc trees (`docs/` and `packages/docs/guide/`) updated in mirrored pairs; VitePress build passes.
- New "Data Change" example in both example apps (dependent-field auto-fill + change log).
- `.agents/skills/wizard-library` references updated.
- Changeset: minor bump for core/react/vue; ROADMAP WIZ-010 marked done.

## Test plan
- [x] Core tests: 280 passed (incl. new `data-change.test.ts` matrix)
- [x] React tests: 103 passed, Vue: 71, state: 34 (core built before framework tests)
- [x] Typecheck: 14/14 tasks
- [x] Lint: clean
- [x] Example apps typecheck + build after lib rebuild
- [x] VitePress docs build