### PR TITLE
feat(core): built-in analytics plugin (WIZ-016)

### DIFF
--- a/.agents/skills/wizard-library/SKILL.md
+++ b/.agents/skills/wizard-library/SKILL.md
@@ -25,6 +25,9 @@ Use this skill to execute Wizard tasks with high correctness and minimal regress
 - Data-change notifications (WIZ-010): `updateField` (Object.is no-op),
   `onDataChange` event, `watchField` (core-only), and the plugin `onDataChange`
   hook. See `references/api_reference.md`.
+- Built-in plugins (WIZ-007 / WIZ-016): `createLoggingPlugin` and
+  `createAnalyticsPlugin` (auto step-timing / backtrack / drop-off with
+  `getReport()`). See `references/api_reference.md`.
 
 ### React (`@gooonzick/wizard-react`)
 

--- a/.agents/skills/wizard-library/references/api_reference.md
+++ b/.agents/skills/wizard-library/references/api_reference.md
@@ -19,6 +19,10 @@ Use public exports from `@gooonzick/wizard-core`:
   and the `WizardEvents.onDataChange(prev, next, changedFields)` event.
 - Transitions: `resolveTransition`, `andGuards`, `orGuards`, `notGuard`, `evaluateGuard`
 - Validators: `requiredFields`, `combineValidators`, `createValidator`, `createStandardSchemaValidator`
+- Built-in plugins: `createLoggingPlugin` (reference logger) and
+  `createAnalyticsPlugin` (auto step-timing / backtrack / drop-off collector with a
+  synchronous `getReport(): AnalyticsReport`). Both are re-exported from the main
+  barrel and from the `@gooonzick/wizard-core/plugins` subpath.
 - Types: `WizardData`, `WizardDefinition`, `WizardStepDefinition`, `StepTransition`, `WizardContext`
 
 Prefer building on exported APIs over importing deep internal modules.
@@ -173,6 +177,23 @@ Use context for external dependencies instead of hard-coding globals in guards/r
   `WizardPlugin` (WIZ-010). `ErrorContext.phase` now includes `"data"`.
 - `snapshot`, its `stepStatuses`, and `snapshot.progress` (with its `enabledStepIds`
   array) are frozen; `snapshot.data` is intentionally NOT frozen.
+
+### Built-in analytics plugin (WIZ-016)
+
+- `createAnalyticsPlugin<TData>(config?)` returns
+  `AnalyticsPlugin<TData> = WizardPlugin<TData> & { getReport(): AnalyticsReport }`.
+- Optional callbacks: `onStepView(stepId, data)`, `onStepComplete(stepId, ms)`,
+  `onBacktrack(from, to)`, `onWizardComplete(data, totalMs)`,
+  `onDropOff(stepId, ms)`. Injectable clock via `now` (default `Date.now`).
+- Timing: a step's timer closes on `afterTransition` (terminal step in `onComplete`);
+  `getReport()` folds the current step's still-open visit into `stepTimings` and
+  `totalDuration`.
+- Backtrack = a `previous` transition OR a `goTo` to an already-viewed step.
+- `onDropOff` fires from `destroy()` ONLY when the wizard never completed.
+- Bookkeeping runs before user callbacks, so a throwing callback cannot corrupt the
+  report. `onReset` restarts the session in place and does NOT re-emit `onStepView`.
+- Register like any plugin: `machine.use(analytics)` or the `plugins` option in
+  `useWizard` / `WizardProvider`.
 
 ## Installation Quick Reference
 

--- a/.changeset/wiz-016-analytics-plugin.md
+++ b/.changeset/wiz-016-analytics-plugin.md
@@ -1,0 +1,8 @@
+---
+"@gooonzick/wizard-core": minor
+---
+
+Add built-in `createAnalyticsPlugin` (WIZ-016): auto-times steps, counts backtracks, records
+drop-off on destroy, fires `onStepView`/`onStepComplete`/`onWizardComplete`/`onDropOff`/
+`onBacktrack` callbacks, and exposes `getReport()`. Exported from the main barrel and the
+`/plugins` subpath alongside `createLoggingPlugin`.

--- a/.changeset/wiz-016-analytics-plugin.md
+++ b/.changeset/wiz-016-analytics-plugin.md
@@ -1,8 +1,13 @@
 ---
 "@gooonzick/wizard-core": minor
+"@gooonzick/wizard-react": minor
+"@gooonzick/wizard-vue": minor
+"@gooonzick/wizard-state": minor
 ---
 
 Add built-in `createAnalyticsPlugin` (WIZ-016): auto-times steps, counts backtracks, records
 drop-off on destroy, fires `onStepView`/`onStepComplete`/`onWizardComplete`/`onDropOff`/
 `onBacktrack` callbacks, and exposes `getReport()`. Exported from the main barrel and the
 `/plugins` subpath alongside `createLoggingPlugin`.
+
+All packages are released together at the same fixed version.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -608,7 +608,7 @@ function createLoggingPlugin<TData>(config?: {
 }): WizardPlugin<TData>;
 ```
 
-Built-in analytics and auto-save plugins remain future work (WIZ-016).
+The built-in analytics plugin has since shipped (WIZ-016, see below); a built-in auto-save plugin remains future work.
 
 ##### React / Vue
 
@@ -1105,7 +1105,7 @@ function App() {
 
 #### WIZ-016: Analytics Helpers
 
-**Status:** 📋 Planned
+**Status:** ✅ Done (see "Shipped vs. specced deltas")
 **Priority:** 🟢 Low
 **Effort:** S (2–3 hours)
 **Package:** `@gooonzick/wizard-core` (as a built-in plugin)
@@ -1180,6 +1180,18 @@ The plugin automatically:
 - onDropOff is called on destroy of an incomplete wizard
 - getReport returns full statistics
 - onWizardComplete is called on completion
+
+##### Shipped vs. specced deltas
+
+- Timer is stopped in `afterTransition` (the committed-success hook), NOT `beforeTransition` as the ticket suggested, so vetoed/stale transitions never falsely close a step or emit `onStepComplete`.
+- Backtrack detection uses `TransitionEvent.type === "previous"` OR `goTo` to an already-viewed step (the plugin has no reliable step-index view), instead of the ticket's "lower index" wording.
+- Timing uses an injectable `now()` (default `Date.now`), NOT `TransitionEvent.timestamp` (which is fixed/non-injectable and `0` in direct-hook tests).
+- `onStepView` data comes from `machine.snapshot.data` (initial) / `e.data` (transitions), both `DeepReadonly<TData>`.
+- `onComplete` also emits `onStepComplete` for the terminal step (its `afterTransition` never fires), in addition to `onWizardComplete`.
+- `onReset` restarts the analytics session in place (clears timings/backtracks/completed, restores the initial step timer) but does NOT re-emit `onStepView` (reset supplies no data).
+- `getReport().stepTimings` folds in the current step's live open-visit time; `totalDuration` is live while running.
+- `destroy` records drop-off only when the wizard was never completed.
+- The plugin's return type is `AnalyticsPlugin<TData> = WizardPlugin<TData> & { getReport(): AnalyticsReport }`.
 
 ---
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,6 +16,6 @@ Complete type and function reference for the Wizard packages.
 
 - [Core Concepts](./core-concepts.md) — state machine, validation (`validate` / `validateAll`), transitions, progress
 - [Defining Wizards](./defining-wizards.md) — declarative, builder, linear helper
-- [Plugins](./plugins.md) — `WizardPlugin`, veto, logging plugin
+- [Plugins](./plugins.md) — `WizardPlugin`, veto, logging + analytics plugins
 - [React Integration](./react-integration.md)
 - [Vue Integration](./vue-integration.md)

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1022,3 +1022,57 @@ function createLoggingPlugin<TData>(config?: {
   logger?: Pick<Console, "log" | "warn" | "debug">; // default: console
 }): WizardPlugin<TData>;
 ```
+
+### `createAnalyticsPlugin`
+
+Built-in analytics collector. Auto-times each step, counts backtracks, records drop-off
+on teardown, and fires optional callbacks. The returned instance adds a synchronous
+`getReport()` method. Never vetoes. Timing uses `config.now` (default `Date.now`), not
+`TransitionEvent.timestamp`, so durations are injectable in tests.
+
+```ts
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+// or: import { createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
+
+function createAnalyticsPlugin<TData>(
+  config?: AnalyticsPluginConfig<TData>,
+): AnalyticsPlugin<TData>;
+
+interface AnalyticsPluginConfig<TData> {
+  onStepView?(stepId: StepId, data: DeepReadonly<TData>): void;
+  onStepComplete?(stepId: StepId, durationMs: number): void;
+  onWizardComplete?(data: DeepReadonly<TData>, totalDurationMs: number): void;
+  /** Fired on destroy() only if the wizard was not completed. */
+  onDropOff?(stepId: StepId, durationMs: number): void;
+  onBacktrack?(fromStepId: StepId, toStepId: StepId): void;
+  /** Injectable clock for testability. Defaults to Date.now. */
+  now?: () => number;
+}
+
+type AnalyticsPlugin<TData> = WizardPlugin<TData> & {
+  getReport(): AnalyticsReport;
+};
+
+interface AnalyticsReport {
+  startedAt: number;
+  stepTimings: Record<StepId, number>; // includes the current step's live open visit
+  backtrackCount: number;
+  backtrackHistory: BacktrackEntry[];
+  currentStep: StepId | null;
+  completed: boolean;
+  totalDuration: number;
+}
+
+interface BacktrackEntry {
+  from: StepId;
+  to: StepId;
+  at: number;
+}
+```
+
+A step's timer closes on `afterTransition` (or in `onComplete` for the terminal step);
+`getReport()` folds the current step's still-open visit into `stepTimings` and
+`totalDuration`. A backtrack is any `previous` transition, or a `goTo` to a
+previously-visited step. `onDropOff` fires from `destroy()` only when the wizard never
+completed. Resetting the wizard restarts the analytics session in place and does not
+re-emit `onStepView`.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -210,21 +210,25 @@ While any navigation (`goNext`, `goPrevious`, `goTo`) is in progress, the machin
 
 ## Import Paths
 
-All plugin types and `createLoggingPlugin` are available from both the main barrel and a dedicated subpath:
+All plugin types, `createLoggingPlugin`, and `createAnalyticsPlugin` are available from both the main barrel and a dedicated subpath:
 
 ```ts
 // Main barrel — works for most cases:
-import { createLoggingPlugin } from "@gooonzick/wizard-core";
+import { createLoggingPlugin, createAnalyticsPlugin } from "@gooonzick/wizard-core";
 import type { WizardPlugin, TransitionEvent, ErrorContext } from "@gooonzick/wizard-core";
 
 // Dedicated subpath — useful for tree-shaking or plugin-only bundles:
-import { createLoggingPlugin } from "@gooonzick/wizard-core/plugins";
+import { createLoggingPlugin, createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
 import type {
   WizardPlugin,
   TransitionEvent,
   ErrorContext,
   WizardMachineReadonly,
   DeepReadonly,
+  AnalyticsReport,
+  BacktrackEntry,
+  AnalyticsPluginConfig,
+  AnalyticsPlugin,
 } from "@gooonzick/wizard-core/plugins";
 ```
 
@@ -263,22 +267,130 @@ function MyWizard() {
 
 ---
 
+## Built-in Plugin: `createAnalyticsPlugin`
+
+The analytics plugin is a second built-in. It automatically times each step, counts
+backward navigations ("backtracks"), records drop-off on teardown, and fires optional
+callbacks. Unlike `createLoggingPlugin`, the returned instance exposes a synchronous
+`getReport()` method for reading aggregated metrics at any time. It never vetoes.
+
+```ts
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+// or: import { createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
+
+const analytics = createAnalyticsPlugin<SignupData>({
+  onStepView: (stepId, data) => track("step_view", { stepId }),
+  onStepComplete: (stepId, durationMs) => track("step_complete", { stepId, durationMs }),
+  onBacktrack: (from, to) => track("backtrack", { from, to }),
+  onWizardComplete: (data, totalDurationMs) => track("wizard_complete", { totalDurationMs }),
+  onDropOff: (stepId, durationMs) => track("drop_off", { stepId, durationMs }),
+  // now: () => Date.now(), // injectable clock; defaults to Date.now
+});
+
+machine.use(analytics);
+
+// Read aggregates at any time — includes the current step's live open-visit time:
+const report = analytics.getReport();
+```
+
+### Config
+
+All callbacks are optional; pass only what you need.
+
+| Option | Signature | When it fires |
+|---|---|---|
+| `onStepView` | `(stepId, data) => void` | On init and on every step entered (including backtracks). |
+| `onStepComplete` | `(stepId, durationMs) => void` | When a step is **left** — on each transition for the departing step, and on completion for the terminal step. |
+| `onBacktrack` | `(fromStepId, toStepId) => void` | On a `previous` transition, or a `goTo` targeting an already-viewed step. |
+| `onWizardComplete` | `(data, totalDurationMs) => void` | When the wizard completes. |
+| `onDropOff` | `(stepId, durationMs) => void` | On teardown (`destroy`) **only if the wizard never completed**. |
+| `now` | `() => number` | Injectable clock used for all timing. Defaults to `Date.now`. |
+
+### `getReport()`
+
+`analytics.getReport()` returns a snapshot of type `AnalyticsReport`:
+
+```ts
+interface AnalyticsReport {
+  startedAt: number;                       // now() at session start (onInit / first hook / last reset)
+  stepTimings: Record<StepId, number>;     // accumulated ms per step, INCLUDING the current live visit
+  backtrackCount: number;                  // number of backward navigations this session
+  backtrackHistory: BacktrackEntry[];      // ordered list of { from, to, at }
+  currentStep: StepId | null;              // most recently entered step, or null before any step
+  completed: boolean;                      // true once onWizardComplete fired (reset clears it)
+  totalDuration: number;                   // completed ? completedAt - startedAt : now() - startedAt
+}
+
+interface BacktrackEntry {
+  from: StepId;
+  to: StepId;
+  at: number;
+}
+```
+
+### Semantics
+
+- **Step timers.** Each step's open visit accumulates elapsed time. A step's timer
+  closes on `afterTransition` (when you leave it); the final step's timer closes in
+  `onComplete`. `getReport()` folds the current step's still-open visit into
+  `stepTimings` and into `totalDuration`, so metrics are always live.
+- **Backtracks.** A backtrack is any `previous` transition, or a `goTo` to a step you
+  have already visited this session.
+- **Drop-off.** `onDropOff` fires from `destroy()` **only if** the wizard was never
+  completed — completed wizards never drop off. In React/Vue this happens automatically
+  on unmount.
+- **Injectable clock.** All durations use `config.now` (default `Date.now`), not the
+  transition `timestamp`, so tests can inject a deterministic clock.
+- **Throw-safe.** The plugin updates its internal bookkeeping *before* invoking your
+  callbacks, so a throwing callback can never corrupt the report.
+- **Reset.** Resetting the wizard restarts the analytics session in place (timings,
+  backtracks, and `completed` are cleared and the initial step's timer restarts). Reset
+  does **not** re-emit `onStepView`.
+
+**React example:**
+
+```tsx
+import { useMemo } from "react";
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+
+function MyWizard() {
+  const analytics = useMemo(
+    () => createAnalyticsPlugin<MyData>({
+      onStepComplete: (stepId, ms) => console.log(stepId, "took", ms, "ms"),
+    }),
+    [],
+  );
+  const plugins = useMemo(() => [analytics], [analytics]);
+
+  const { state } = useWizard({ definition, initialData, plugins });
+
+  // Read live aggregates whenever you need them:
+  const onShowReport = () => console.log(analytics.getReport());
+  // ...
+}
+```
+
+---
+
 ## Writing Your Own Plugin
 
-A plugin is a plain object with a `name` and any subset of the optional hooks. Here is a minimal analytics plugin:
+A plugin is a plain object with a `name` and any subset of the optional hooks. (For
+built-in analytics use `createAnalyticsPlugin` above; the example below shows how you
+would build a custom tracking plugin from scratch.) Here is a minimal tracking
+plugin:
 
 ```ts
 import type { WizardPlugin, TransitionEvent, DeepReadonly } from "@gooonzick/wizard-core";
 
-interface AnalyticsConfig {
+interface TrackingConfig {
   track: (event: string, props?: Record<string, unknown>) => void;
 }
 
-function createAnalyticsPlugin<TData>(
-  config: AnalyticsConfig,
+function createTrackingPlugin<TData>(
+  config: TrackingConfig,
 ): WizardPlugin<TData> {
   return {
-    name: "analytics",
+    name: "tracking",
 
     onInit(machine) {
       config.track("wizard_init", {
@@ -317,7 +429,7 @@ function createAnalyticsPlugin<TData>(
 
 ```ts
 const machine = new WizardMachine(definition, context, initialData, events, [
-  createAnalyticsPlugin({ track: myAnalyticsLib.track }),
+  createTrackingPlugin({ track: myAnalyticsLib.track }),
   createLoggingPlugin({ level: "warn" }),
 ]);
 ```
@@ -326,7 +438,7 @@ Or with React:
 
 ```tsx
 const plugins = useMemo(
-  () => [createAnalyticsPlugin({ track: myAnalyticsLib.track })],
+  () => [createTrackingPlugin({ track: myAnalyticsLib.track })],
   [],
 );
 

--- a/examples/react-examples/src/App.tsx
+++ b/examples/react-examples/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { AnalyticsExample } from "./analytics-example";
 import { DataChangeExample } from "./data-change-example";
 import { HistoryExample } from "./history-example";
 import { PluginsExample } from "./plugins-example";
@@ -14,6 +15,7 @@ type View =
 	| "reset-cancel"
 	| "persistence"
 	| "plugins"
+	| "analytics"
 	| "data-change";
 
 export function App() {
@@ -26,6 +28,7 @@ export function App() {
 		{ id: "reset-cancel", label: "Reset & Cancel" },
 		{ id: "persistence", label: "State Persistence" },
 		{ id: "plugins", label: "Plugins" },
+		{ id: "analytics", label: "Analytics" },
 		{ id: "data-change", label: "Data Change" },
 	];
 
@@ -53,6 +56,7 @@ export function App() {
 			{view === "reset-cancel" && <ResetCancelExample />}
 			{view === "persistence" && <StatePersistenceExample />}
 			{view === "plugins" && <PluginsExample />}
+			{view === "analytics" && <AnalyticsExample />}
 			{view === "data-change" && <DataChangeExample />}
 		</div>
 	);

--- a/examples/react-examples/src/analytics-example.tsx
+++ b/examples/react-examples/src/analytics-example.tsx
@@ -1,0 +1,169 @@
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+import { useWizard } from "@gooonzick/wizard-react";
+import type React from "react";
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { WizardForm } from "./components/wizard-form";
+import { WizardProgress } from "./components/wizard-progress";
+import {
+	type RegistrationData,
+	registrationInitialData,
+	registrationStepTitles,
+	registrationWizard,
+} from "./registration-wizard";
+
+/**
+ * Demo of the WIZ-016 built-in analytics plugin. `createAnalyticsPlugin` auto-times
+ * each step and counts backtracks; `analytics.getReport()` returns a live snapshot
+ * (including the current step's still-open visit). Callbacks append a human-readable
+ * event feed.
+ */
+type EventEntry = { id: string; text: string };
+
+let analyticsSeq = 0;
+
+export const AnalyticsExample: React.FC = () => {
+	const [events, setEvents] = useState<EventEntry[]>([]);
+	// Re-render trigger so the report panel reflects the latest getReport().
+	const [, force] = useState(0);
+
+	// Reference-stable analytics instance (read once at machine creation).
+	const analytics = useMemo(() => {
+		const push = (text: string) => {
+			const id = `ev-${++analyticsSeq}`;
+			setEvents((prev) => [...prev.slice(-19), { id, text }]);
+		};
+
+		return createAnalyticsPlugin<RegistrationData>({
+			onStepView: (stepId) => push(`view: ${stepId}`),
+			onStepComplete: (stepId, ms) => push(`complete: ${stepId} (${ms}ms)`),
+			onBacktrack: (from, to) => push(`backtrack: ${from} → ${to}`),
+			onWizardComplete: (_data, total) =>
+				push(`wizard complete (${total}ms total)`),
+			onDropOff: (stepId, ms) => push(`drop-off: ${stepId} (${ms}ms)`),
+		});
+	}, []);
+
+	const plugins = useMemo(() => [analytics], [analytics]);
+
+	const { navigation, actions, state, validation } = useWizard({
+		definition: registrationWizard,
+		initialData: registrationInitialData,
+		plugins,
+	});
+
+	const report = analytics.getReport();
+
+	return (
+		<div className="min-h-screen bg-gray-50 py-8 px-4">
+			<div className="max-w-7xl mx-auto">
+				<div className="mb-8">
+					<h1 className="text-3xl font-bold text-gray-900">Analytics Plugin</h1>
+					<p className="text-gray-600 mt-2">
+						Built-in <code>createAnalyticsPlugin</code>: per-step timing,
+						backtrack counting, and a live <code>getReport()</code> snapshot.
+					</p>
+				</div>
+
+				<WizardProgress
+					progress={state.progress}
+					stepTitles={registrationStepTitles}
+					stepStatuses={state.stepStatuses}
+					onStepClick={(stepId) => navigation.goTo(stepId)}
+				/>
+
+				<div className="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6">
+					<div>
+						<WizardForm
+							currentStepId={state.currentStep.id}
+							data={state.data}
+							validationErrors={validation.validationErrors}
+							onFieldChange={actions.updateField}
+						/>
+
+						<div className="flex gap-4 mt-6">
+							<Button
+								variant="outline"
+								onClick={() => navigation.goPrevious()}
+								disabled={!navigation.canGoPrevious}
+							>
+								Previous
+							</Button>
+							{!navigation.isLastStep ? (
+								<Button
+									onClick={() => navigation.goNext()}
+									disabled={!navigation.canGoNext}
+								>
+									Next
+								</Button>
+							) : (
+								<Button
+									onClick={() => actions.submit()}
+									className="bg-green-600 hover:bg-green-700"
+								>
+									Submit
+								</Button>
+							)}
+							<Button variant="outline" onClick={() => actions.reset()}>
+								Reset
+							</Button>
+							<Button variant="outline" onClick={() => force((n) => n + 1)}>
+								Refresh report
+							</Button>
+						</div>
+					</div>
+
+					<div className="bg-white border rounded-lg p-4 shadow-sm space-y-4">
+						<div>
+							<h2 className="font-semibold text-gray-900 mb-2">Report</h2>
+							<dl className="text-sm text-gray-700 space-y-1">
+								<div className="flex justify-between">
+									<dt>Current step</dt>
+									<dd className="font-mono">{report.currentStep ?? "—"}</dd>
+								</div>
+								<div className="flex justify-between">
+									<dt>Backtracks</dt>
+									<dd className="font-mono">{report.backtrackCount}</dd>
+								</div>
+								<div className="flex justify-between">
+									<dt>Total (ms)</dt>
+									<dd className="font-mono">{report.totalDuration}</dd>
+								</div>
+								<div className="flex justify-between">
+									<dt>Completed</dt>
+									<dd className="font-mono">{String(report.completed)}</dd>
+								</div>
+							</dl>
+							<h3 className="font-medium text-gray-800 mt-3 mb-1">
+								Step timings (ms)
+							</h3>
+							<ul className="text-sm font-mono text-gray-700 space-y-1">
+								{Object.entries(report.stepTimings).map(([id, ms]) => (
+									<li key={id} className="flex justify-between">
+										<span>{id}</span>
+										<span>{ms}</span>
+									</li>
+								))}
+							</ul>
+						</div>
+
+						<div>
+							<h2 className="font-semibold text-gray-900 mb-2">Event feed</h2>
+							{events.length === 0 ? (
+								<p className="text-sm text-gray-500">
+									Navigate the wizard to see analytics callbacks fire.
+								</p>
+							) : (
+								<ul className="space-y-1 text-sm font-mono text-gray-700 max-h-64 overflow-y-auto">
+									{events.map((entry) => (
+										<li key={entry.id}>{entry.text}</li>
+									))}
+								</ul>
+							)}
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+};

--- a/examples/vue-examples/src/App.vue
+++ b/examples/vue-examples/src/App.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { onMounted, ref, watch } from "vue";
 import ApproachToggle from "./components/approach-toggle.vue";
+import AnalyticsExample from "./wizard-example/analytics-example.vue";
 import DataChangeExample from "./wizard-example/data-change-example.vue";
 import FieldBindingExample from "./wizard-example/field-binding-example.vue";
 import HistoryExample from "./wizard-example/history-example.vue";
@@ -18,6 +19,7 @@ type Approach =
 	| "reset-cancel"
 	| "persistence"
 	| "plugins"
+	| "analytics"
 	| "data-change";
 
 const approaches: Approach[] = [
@@ -28,6 +30,7 @@ const approaches: Approach[] = [
 	"reset-cancel",
 	"persistence",
 	"plugins",
+	"analytics",
 	"data-change",
 ];
 
@@ -64,6 +67,7 @@ watch(approach, (newVal) => {
 			<ResetCancelExample v-else-if="approach === 'reset-cancel'" />
 			<StatePersistenceExample v-else-if="approach === 'persistence'" />
 			<PluginsExample v-else-if="approach === 'plugins'" />
+			<AnalyticsExample v-else-if="approach === 'analytics'" />
 			<DataChangeExample v-else-if="approach === 'data-change'" />
 		</div>
 	</div>

--- a/examples/vue-examples/src/components/approach-toggle.vue
+++ b/examples/vue-examples/src/components/approach-toggle.vue
@@ -10,6 +10,7 @@ type Approach =
 	| "reset-cancel"
 	| "persistence"
 	| "plugins"
+	| "analytics"
 	| "data-change";
 
 interface Props {
@@ -69,6 +70,12 @@ defineEmits<
 			@click="$emit('update:modelValue', 'plugins')"
 		>
 			Plugins
+		</Button>
+		<Button
+			:variant="modelValue === 'analytics' ? 'default' : 'outline'"
+			@click="$emit('update:modelValue', 'analytics')"
+		>
+			Analytics
 		</Button>
 		<Button
 			:variant="modelValue === 'data-change' ? 'default' : 'outline'"

--- a/examples/vue-examples/src/wizard-example/analytics-example.vue
+++ b/examples/vue-examples/src/wizard-example/analytics-example.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+import { useWizard } from "@gooonzick/wizard-vue";
+import { computed, ref } from "vue";
+import Button from "@/components/ui/button.vue";
+import Card from "@/components/ui/card.vue";
+import WizardForm from "@/components/wizard-form.vue";
+import WizardProgress from "@/components/wizard-progress.vue";
+import type { RegistrationData } from "../types/wizard-data";
+import { stepTitles } from "./constants";
+import { initialData } from "./initial-data";
+import { advancedWizard } from "./wizard-definition";
+
+// Demo of the WIZ-016 built-in analytics plugin: per-step timing, backtrack
+// counting, and a live getReport() snapshot.
+type EventEntry = { id: string; text: string };
+
+let analyticsSeq = 0;
+const events = ref<EventEntry[]>([]);
+const reportTick = ref(0);
+
+const push = (text: string) => {
+	const id = `ev-${++analyticsSeq}`;
+	events.value = [...events.value.slice(-19), { id, text }];
+	reportTick.value += 1;
+};
+
+// Reference-stable — read once at machine creation (not reactive).
+const analytics = createAnalyticsPlugin<RegistrationData>({
+	onStepView: (stepId) => push(`view: ${stepId}`),
+	onStepComplete: (stepId, ms) => push(`complete: ${stepId} (${ms}ms)`),
+	onBacktrack: (from, to) => push(`backtrack: ${from} → ${to}`),
+	onWizardComplete: (_data, total) => push(`wizard complete (${total}ms total)`),
+	onDropOff: (stepId, ms) => push(`drop-off: ${stepId} (${ms}ms)`),
+});
+
+const plugins = [analytics];
+
+const { navigation, actions, state, validation } = useWizard({
+	definition: advancedWizard,
+	initialData,
+	plugins,
+});
+
+// reportTick is a dependency so the panel recomputes after each callback / manual refresh.
+const report = computed(() => {
+	void reportTick.value;
+	return analytics.getReport();
+});
+const stepTimingEntries = computed(() => Object.entries(report.value.stepTimings));
+</script>
+
+<template>
+	<div class="min-h-screen bg-gray-50 py-8 px-4">
+		<div class="max-w-7xl mx-auto">
+			<div class="mb-8">
+				<h1 class="text-3xl font-bold text-gray-900">Analytics Plugin</h1>
+				<p class="text-gray-600 mt-2">
+					Built-in <code>createAnalyticsPlugin</code>: per-step timing,
+					backtrack counting, and a live <code>getReport()</code> snapshot.
+				</p>
+			</div>
+
+			<WizardProgress
+				:progress="state.progress.value"
+				:step-titles="stepTitles"
+				:step-statuses="state.stepStatuses.value"
+			/>
+
+			<div class="grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6 mt-6">
+				<Card class="p-8">
+					<WizardForm
+						:current-step-id="state.currentStepId.value"
+						:data="state.data.value"
+						:validation-errors="validation.validationErrors.value"
+						:on-field-change="actions.updateField"
+					/>
+
+					<div class="flex flex-wrap gap-4 mt-6">
+						<Button
+							variant="outline"
+							:disabled="!navigation.canGoPrevious.value"
+							@click="navigation.goPrevious"
+						>
+							Previous
+						</Button>
+						<template v-if="!navigation.isLastStep.value">
+							<Button
+								:disabled="!navigation.canGoNext.value"
+								@click="navigation.goNext"
+							>
+								Next
+							</Button>
+						</template>
+						<template v-else>
+							<Button
+								class="bg-green-600 hover:bg-green-700"
+								@click="actions.submit"
+							>
+								Submit
+							</Button>
+						</template>
+						<Button variant="outline" @click="actions.reset()">
+							Reset
+						</Button>
+						<Button variant="outline" @click="reportTick += 1">
+							Refresh report
+						</Button>
+					</div>
+				</Card>
+
+				<div class="bg-white border rounded-lg p-4 shadow-sm space-y-4">
+					<div>
+						<h2 class="font-semibold text-gray-900 mb-2">Report</h2>
+						<dl class="text-sm text-gray-700 space-y-1">
+							<div class="flex justify-between">
+								<dt>Current step</dt>
+								<dd class="font-mono">{{ report.currentStep ?? "—" }}</dd>
+							</div>
+							<div class="flex justify-between">
+								<dt>Backtracks</dt>
+								<dd class="font-mono">{{ report.backtrackCount }}</dd>
+							</div>
+							<div class="flex justify-between">
+								<dt>Total (ms)</dt>
+								<dd class="font-mono">{{ report.totalDuration }}</dd>
+							</div>
+							<div class="flex justify-between">
+								<dt>Completed</dt>
+								<dd class="font-mono">{{ String(report.completed) }}</dd>
+							</div>
+						</dl>
+						<h3 class="font-medium text-gray-800 mt-3 mb-1">
+							Step timings (ms)
+						</h3>
+						<ul class="text-sm font-mono text-gray-700 space-y-1">
+							<li
+								v-for="[id, ms] in stepTimingEntries"
+								:key="id"
+								class="flex justify-between"
+							>
+								<span>{{ id }}</span>
+								<span>{{ ms }}</span>
+							</li>
+						</ul>
+					</div>
+
+					<div>
+						<h2 class="font-semibold text-gray-900 mb-2">Event feed</h2>
+						<p v-if="events.length === 0" class="text-sm text-gray-500">
+							Navigate the wizard to see analytics callbacks fire.
+						</p>
+						<ul
+							v-else
+							class="space-y-1 text-sm font-mono text-gray-700 max-h-64 overflow-y-auto"
+						>
+							<li v-for="entry in events" :key="entry.id">
+								{{ entry.text }}
+							</li>
+						</ul>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</template>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,7 +43,14 @@ export {
 	type WizardSerializedState,
 	type WizardState,
 } from "./machine/wizard-machine";
+export type {
+	AnalyticsPlugin,
+	AnalyticsPluginConfig,
+	AnalyticsReport,
+	BacktrackEntry,
+} from "./plugins/analytics";
 // Plugins (WIZ-007)
+export { createAnalyticsPlugin } from "./plugins/analytics";
 export { createLoggingPlugin } from "./plugins/logging";
 export type {
 	DeepReadonly,

--- a/packages/core/src/plugins/analytics.ts
+++ b/packages/core/src/plugins/analytics.ts
@@ -1,6 +1,8 @@
+import type { WizardError } from "../errors";
 import type { StepId } from "../types/base";
 import type {
 	DeepReadonly,
+	ErrorContext,
 	TransitionEvent,
 	WizardMachineReadonly,
 	WizardPlugin,
@@ -55,6 +57,15 @@ export type AnalyticsPlugin<TData> = WizardPlugin<TData> & {
  *
  * Timing uses `config.now` (default `Date.now`) — NOT `TransitionEvent.timestamp` — so
  * durations are injectable/deterministic in tests.
+ *
+ * `onInit` fully re-seeds the session (idempotent under React StrictMode re-mounts).
+ * On an `onEnter` throw the machine stays on the committed target but never fires
+ * `afterTransition`; the plugin resyncs via `onError` (phase `"transition"`, whose
+ * `ctx.stepId` is the committed step) and, as a deterministic backstop, self-heals in
+ * `afterTransition` when `e.fromStepId` no longer matches its last-known step. When the
+ * plugin is added mid-transition via `use()`, it absorbs the already-accounted in-flight
+ * `afterTransition` instead of double-counting it. Recovery is "forward-only": missed steps
+ * get no fabricated `onStepView`/`onStepComplete`.
  */
 export function createAnalyticsPlugin<TData>(
 	config: AnalyticsPluginConfig<TData> = {},
@@ -74,6 +85,7 @@ export function createAnalyticsPlugin<TData>(
 	const viewedSteps = new Set<StepId>(); // for goTo-backward detection
 	let backtracks = 0;
 	const backtrackHistory: BacktrackEntry[] = [];
+	let awaitingInitTransition = false; // true from onInit until the first afterTransition
 
 	/** Lazily start a session if onInit never ran (defensive for direct-hook tests). */
 	function ensureStarted(at: number): void {
@@ -98,15 +110,23 @@ export function createAnalyticsPlugin<TData>(
 
 		onInit(machine: WizardMachineReadonly<TData>): void {
 			const at = now();
+			// Full re-seed: onInit MUST be idempotent. Under React StrictMode / concurrent
+			// rendering the SAME plugin instance is destroyed and re-onInit-ed, so clear ALL
+			// prior-session residue (mirrors onReset) — not just the scalar fields.
 			initialized = true;
 			startedAt = at;
 			completed = false;
 			completedAt = null;
+			backtracks = 0;
+			backtrackHistory.length = 0;
+			viewedSteps.clear();
+			for (const k of Object.keys(stepTimings)) delete stepTimings[k];
 			const id = machine.snapshot.currentStepId;
 			initialStepId = id;
 			currentStepId = id;
 			activeSince = at;
 			timerOpen = true;
+			awaitingInitTransition = true; // see Finding 3: absorb an in-flight use() transition
 			viewedSteps.add(id);
 			// internal state is fully consistent before the user callback:
 			config.onStepView?.(id, machine.snapshot.data);
@@ -115,6 +135,33 @@ export function createAnalyticsPlugin<TData>(
 		afterTransition(e: TransitionEvent<TData>): void {
 			const at = now();
 			ensureStarted(at);
+
+			// ── Finding 3: absorb the in-flight transition that use() added us into ──
+			const wasAwaitingInit = awaitingInitTransition;
+			awaitingInitTransition = false;
+			if (
+				wasAwaitingInit &&
+				e.toStepId === currentStepId && // onInit already seeded the target
+				!viewedSteps.has(e.fromStepId) // and the from step is genuinely unseen
+			) {
+				// use() registered this plugin mid-transition: state was already committed
+				// to e.toStepId when onInit seeded it, so this afterTransition is the SAME
+				// transition onInit already accounted for. Absorb it — no timer close, no
+				// callbacks, no backtrack — but record the from step as previously visited
+				// so later backtrack detection stays correct.
+				viewedSteps.add(e.fromStepId);
+				return;
+			}
+
+			// ── Finding 2 backstop: we missed one or more transitions (e.g. onEnter threw
+			//    and onError did not resync us). Reconcile forward without fabricating
+			//    callbacks for the missed step(s). ──
+			if (currentStepId !== null && e.fromStepId !== currentStepId) {
+				closeTimer(at); // silently accumulate into the stale last-known step
+				currentStepId = e.fromStepId;
+				timerOpen = false; // no open timer for a step we never actually entered
+				viewedSteps.add(e.fromStepId);
+			}
 
 			// 1. close the departing step's timer (currentStepId == e.fromStepId here)
 			const closedId = timerOpen ? currentStepId : null;
@@ -143,6 +190,29 @@ export function createAnalyticsPlugin<TData>(
 			config.onStepView?.(e.toStepId, e.data);
 		},
 
+		onError(_error: WizardError | Error, ctx: ErrorContext<TData>): void {
+			// FIX F4 desync recovery. On an onEnter throw the machine stays on the
+			// committed target but afterTransition never fires, leaving our currentStepId
+			// stale. For a "transition"-phase error ctx.stepId is the machine's real
+			// committed step, so re-point to it. Other phases (validation/lifecycle/submit/
+			// data) do not move the committed step, so ignore them.
+			if (ctx.phase !== "transition") return;
+			if (!initialized) return;
+			if (ctx.stepId === currentStepId) return; // already in sync — nothing to do
+			const at = now();
+			// Close the stale step's timer silently. Do NOT fire onStepComplete: the
+			// transition did not "succeed" (mirrors the machine suppressing onStepEnter /
+			// afterTransition on an onEnter throw) and we must not fabricate callbacks.
+			closeTimer(at);
+			currentStepId = ctx.stepId;
+			activeSince = at;
+			timerOpen = true;
+			awaitingInitTransition = false; // this is a real (failed) entry, not the init one
+			viewedSteps.add(ctx.stepId);
+			// Deliberately no onStepView here: the entry FAILED; onStepView is reserved for
+			// successful entries (the machine likewise never fired onStepEnter for it).
+		},
+
 		onComplete(data: DeepReadonly<TData>): void {
 			const at = now();
 			ensureStarted(at);
@@ -163,6 +233,7 @@ export function createAnalyticsPlugin<TData>(
 			const at = now();
 			startedAt = at;
 			initialized = true;
+			awaitingInitTransition = false; // a post-reset transition must not trigger the absorb guard
 			completed = false;
 			completedAt = null;
 			backtracks = 0;

--- a/packages/core/src/plugins/analytics.ts
+++ b/packages/core/src/plugins/analytics.ts
@@ -1,0 +1,214 @@
+import type { StepId } from "../types/base";
+import type {
+	DeepReadonly,
+	TransitionEvent,
+	WizardMachineReadonly,
+	WizardPlugin,
+} from "./types";
+
+/** One recorded backward navigation. */
+export interface BacktrackEntry {
+	from: StepId;
+	to: StepId;
+	at: number;
+}
+
+/** Aggregated analytics snapshot returned by `getReport()`. */
+export interface AnalyticsReport {
+	/** `now()` at session start (onInit, or first hook if onInit never ran, or last reset). */
+	startedAt: number;
+	/** Accumulated ms per step id, INCLUDING the current step's open visit so far. */
+	stepTimings: Record<StepId, number>;
+	/** Number of backward navigations recorded this session. */
+	backtrackCount: number;
+	/** Ordered list of backward navigations. */
+	backtrackHistory: BacktrackEntry[];
+	/** Most recently entered step, or null before any step is known. */
+	currentStep: StepId | null;
+	/** True once onWizardComplete has fired (reset clears it). */
+	completed: boolean;
+	/** completed ? completedAt - startedAt : now() - startedAt. */
+	totalDuration: number;
+}
+
+/** Callbacks + injectable clock. All callbacks optional. */
+export interface AnalyticsPluginConfig<TData> {
+	onStepView?(stepId: StepId, data: DeepReadonly<TData>): void;
+	onStepComplete?(stepId: StepId, durationMs: number): void;
+	onWizardComplete?(data: DeepReadonly<TData>, totalDurationMs: number): void;
+	/** Fired on destroy() only if the wizard was not completed. */
+	onDropOff?(stepId: StepId, durationMs: number): void;
+	onBacktrack?(fromStepId: StepId, toStepId: StepId): void;
+	/** Injectable clock for testability. Defaults to Date.now. */
+	now?: () => number;
+}
+
+/** A WizardPlugin augmented with a synchronous report getter. */
+export type AnalyticsPlugin<TData> = WizardPlugin<TData> & {
+	getReport(): AnalyticsReport;
+};
+
+/**
+ * Built-in analytics collector. Auto-times each step, counts backtracks, records
+ * drop-off on destroy, and fires user callbacks. Register with `machine.use(analytics)`
+ * and read aggregates via `analytics.getReport()`.
+ *
+ * Timing uses `config.now` (default `Date.now`) — NOT `TransitionEvent.timestamp` — so
+ * durations are injectable/deterministic in tests.
+ */
+export function createAnalyticsPlugin<TData>(
+	config: AnalyticsPluginConfig<TData> = {},
+): AnalyticsPlugin<TData> {
+	const now = config.now ?? Date.now;
+
+	// ── session state ──────────────────────────────────────────────
+	let initialized = false;
+	let startedAt = 0;
+	let initialStepId: StepId | null = null; // captured in onInit, used by onReset
+	let currentStepId: StepId | null = null; // most recently entered step
+	let activeSince = 0; // now() when the current visit started
+	let timerOpen = false; // is the current visit still accumulating?
+	let completed = false;
+	let completedAt: number | null = null;
+	const stepTimings: Record<StepId, number> = {};
+	const viewedSteps = new Set<StepId>(); // for goTo-backward detection
+	let backtracks = 0;
+	const backtrackHistory: BacktrackEntry[] = [];
+
+	/** Lazily start a session if onInit never ran (defensive for direct-hook tests). */
+	function ensureStarted(at: number): void {
+		if (!initialized) {
+			initialized = true;
+			startedAt = at;
+		}
+	}
+
+	/** Accumulate the open visit's elapsed time into stepTimings and mark it closed.
+	 *  Returns the closed visit's duration, or null if no timer was open. */
+	function closeTimer(at: number): number | null {
+		if (!timerOpen || currentStepId === null) return null;
+		const d = at - activeSince;
+		stepTimings[currentStepId] = (stepTimings[currentStepId] ?? 0) + d;
+		timerOpen = false;
+		return d;
+	}
+
+	return {
+		name: "analytics",
+
+		onInit(machine: WizardMachineReadonly<TData>): void {
+			const at = now();
+			initialized = true;
+			startedAt = at;
+			completed = false;
+			completedAt = null;
+			const id = machine.snapshot.currentStepId;
+			initialStepId = id;
+			currentStepId = id;
+			activeSince = at;
+			timerOpen = true;
+			viewedSteps.add(id);
+			// internal state is fully consistent before the user callback:
+			config.onStepView?.(id, machine.snapshot.data);
+		},
+
+		afterTransition(e: TransitionEvent<TData>): void {
+			const at = now();
+			ensureStarted(at);
+
+			// 1. close the departing step's timer (currentStepId == e.fromStepId here)
+			const closedId = timerOpen ? currentStepId : null;
+			const closedDuration = closeTimer(at);
+
+			// 2. backtrack detection (do BEFORE marking the target viewed)
+			const isBacktrack =
+				e.type === "previous" ||
+				(e.type === "goTo" && viewedSteps.has(e.toStepId));
+			if (isBacktrack) {
+				backtracks += 1;
+				backtrackHistory.push({ from: e.fromStepId, to: e.toStepId, at });
+			}
+
+			// 3. open the entered step's timer
+			currentStepId = e.toStepId;
+			activeSince = at;
+			timerOpen = true;
+			viewedSteps.add(e.toStepId);
+
+			// 4. fire callbacks — state already consistent, a throw cannot corrupt it
+			if (closedId !== null && closedDuration !== null) {
+				config.onStepComplete?.(closedId, closedDuration);
+			}
+			if (isBacktrack) config.onBacktrack?.(e.fromStepId, e.toStepId);
+			config.onStepView?.(e.toStepId, e.data);
+		},
+
+		onComplete(data: DeepReadonly<TData>): void {
+			const at = now();
+			ensureStarted(at);
+			const closedId = timerOpen ? currentStepId : null;
+			const closedDuration = closeTimer(at);
+			completed = true;
+			completedAt = at;
+			const total = at - startedAt;
+			if (closedId !== null && closedDuration !== null) {
+				config.onStepComplete?.(closedId, closedDuration);
+			}
+			config.onWizardComplete?.(data, total);
+		},
+
+		onReset(): void {
+			// Restart the analytics session in place. Reset provides no stepId/data, so we
+			// restore the initial step (captured in onInit) and do NOT emit onStepView.
+			const at = now();
+			startedAt = at;
+			initialized = true;
+			completed = false;
+			completedAt = null;
+			backtracks = 0;
+			backtrackHistory.length = 0;
+			viewedSteps.clear();
+			for (const k of Object.keys(stepTimings)) delete stepTimings[k];
+			currentStepId = initialStepId;
+			if (currentStepId !== null) {
+				viewedSteps.add(currentStepId);
+				activeSince = at;
+				timerOpen = true;
+			} else {
+				timerOpen = false;
+			}
+		},
+
+		destroy(): void {
+			const at = now();
+			ensureStarted(at);
+			if (completed) return; // completed wizards never drop off
+			if (currentStepId === null) return;
+			const d = timerOpen ? at - activeSince : 0;
+			if (timerOpen) {
+				stepTimings[currentStepId] = (stepTimings[currentStepId] ?? 0) + d;
+				timerOpen = false;
+			}
+			config.onDropOff?.(currentStepId, d);
+		},
+
+		getReport(): AnalyticsReport {
+			const live: Record<StepId, number> = { ...stepTimings };
+			if (timerOpen && currentStepId !== null) {
+				live[currentStepId] =
+					(live[currentStepId] ?? 0) + (now() - activeSince);
+			}
+			return {
+				startedAt,
+				stepTimings: live,
+				backtrackCount: backtracks,
+				backtrackHistory: backtrackHistory.map((b) => ({ ...b })),
+				currentStep: currentStepId,
+				completed,
+				totalDuration: completed
+					? (completedAt ?? startedAt) - startedAt
+					: now() - startedAt,
+			};
+		},
+	};
+}

--- a/packages/core/src/plugins/index.ts
+++ b/packages/core/src/plugins/index.ts
@@ -1,3 +1,10 @@
+export type {
+	AnalyticsPlugin,
+	AnalyticsPluginConfig,
+	AnalyticsReport,
+	BacktrackEntry,
+} from "./analytics";
+export { createAnalyticsPlugin } from "./analytics";
 export { createLoggingPlugin } from "./logging";
 export type {
 	DeepReadonly,

--- a/packages/core/tests/analytics-integration.test.ts
+++ b/packages/core/tests/analytics-integration.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { WizardMachine } from "../src/machine/wizard-machine";
+import { createAnalyticsPlugin } from "../src/plugins/analytics";
+import { createSimpleLinearDefinition, type SimpleData } from "./fixtures";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const initial: SimpleData = { name: "a", email: "a@x.io" };
+
+// controllable clock, injected into the analytics plugin for deterministic durations
+const makeClock = () => {
+	let t = 1000;
+	return {
+		now: () => t,
+		advance: (ms: number) => {
+			t += ms;
+		},
+	};
+};
+
+describe("createAnalyticsPlugin — integration with a real WizardMachine", () => {
+	it("tracks onStepView sequence, backtrackCount, onWizardComplete and onDropOff across real navigation", async () => {
+		const clock = makeClock();
+		const stepViews: string[] = [];
+		let backtrackCount = 0;
+		let wizardCompleted: { data: SimpleData; total: number } | undefined;
+
+		const analytics = createAnalyticsPlugin<SimpleData>({
+			now: clock.now,
+			onStepView: (stepId) => stepViews.push(stepId),
+			onBacktrack: () => {
+				backtrackCount += 1;
+			},
+			onWizardComplete: (data, total) => {
+				wizardCompleted = { data: data as SimpleData, total };
+			},
+		});
+
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[analytics],
+		);
+		await flush(); // onInit is fire-and-forget
+
+		clock.advance(100);
+		await m.goNext(); // step1 -> step2
+		clock.advance(50);
+		await m.goPrevious(); // step2 -> step1 (backtrack)
+		clock.advance(75);
+		await m.goNext(); // step1 -> step2
+		clock.advance(120);
+		await m.goTo("step3", { skipValidation: true }); // step2 -> step3
+		clock.advance(200);
+		await m.submit(); // completes on step3
+		await flush();
+
+		expect(stepViews).toEqual(["step1", "step2", "step1", "step2", "step3"]);
+		expect(backtrackCount).toBe(1);
+		expect(wizardCompleted).toBeDefined();
+		expect(wizardCompleted?.data.name).toBe("a");
+
+		const report = analytics.getReport();
+		expect(report.completed).toBe(true);
+		expect(report.backtrackCount).toBe(1);
+	});
+
+	it("emits onDropOff when destroy() is called before completion", async () => {
+		const clock = makeClock();
+		let dropOff: { stepId: string; duration: number } | undefined;
+		const analytics = createAnalyticsPlugin<SimpleData>({
+			now: clock.now,
+			onDropOff: (stepId, durationMs) => {
+				dropOff = { stepId, duration: durationMs };
+			},
+		});
+
+		const m = new WizardMachine<SimpleData>(
+			createSimpleLinearDefinition(),
+			{},
+			initial,
+			{},
+			[analytics],
+		);
+		await flush();
+
+		clock.advance(60);
+		await m.goNext(); // step1 -> step2
+		clock.advance(90);
+		await m.destroy();
+
+		expect(dropOff).toEqual({ stepId: "step2", duration: 90 });
+		expect(analytics.getReport().completed).toBe(false);
+	});
+});

--- a/packages/core/tests/analytics-integration.test.ts
+++ b/packages/core/tests/analytics-integration.test.ts
@@ -93,4 +93,44 @@ describe("createAnalyticsPlugin — integration with a real WizardMachine", () =
 		expect(dropOff).toEqual({ stepId: "step2", duration: 90 });
 		expect(analytics.getReport().completed).toBe(false);
 	});
+
+	it("recovers currentStep and timings after a step's onEnter throws once (FIX F4 desync)", async () => {
+		const clock = makeClock();
+		const onStepComplete: Array<[string, number]> = [];
+		const analytics = createAnalyticsPlugin<SimpleData>({
+			now: clock.now,
+			onStepComplete: (stepId, ms) => onStepComplete.push([stepId, ms]),
+		});
+
+		const def = createSimpleLinearDefinition();
+		let entered = 0;
+		// step2.onEnter throws the FIRST time it is entered, succeeds afterwards.
+		(def.steps.step2 as { onEnter?: unknown }).onEnter = () => {
+			entered += 1;
+			if (entered === 1) throw new Error("boom");
+		};
+
+		const m = new WizardMachine<SimpleData>(def, {}, initial, {}, [analytics]);
+		await flush(); // onInit at step1
+
+		clock.advance(100);
+		// step1 -> step2 : machine commits to step2, onEnter throws; afterTransition skipped.
+		await expect(m.goNext()).rejects.toThrow("boom");
+		await flush(); // let the fire-and-forget onError resync run
+
+		// onError resynced the plugin to the committed step2.
+		expect(analytics.getReport().currentStep).toBe("step2");
+
+		clock.advance(200);
+		await m.goNext(); // step2 -> step3 (onEnter of step3 fine)
+		await flush();
+
+		// currentStep is correct, and step2's timer was attributed to step2 (not step1).
+		const report = analytics.getReport();
+		expect(report.currentStep).toBe("step3");
+		// step2 completed with its real dwell (~200ms) — NOT folded into step1.
+		expect(onStepComplete).toContainEqual(["step2", 200]);
+		expect(report.stepTimings.step1).toBe(100);
+		expect(report.stepTimings.step2).toBe(200);
+	});
 });

--- a/packages/core/tests/analytics-plugin.test.ts
+++ b/packages/core/tests/analytics-plugin.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAnalyticsPlugin } from "../src/plugins/analytics";
+import type { TransitionEvent } from "../src/plugins/types";
+
+interface D extends Record<string, unknown> {
+	value: number;
+}
+
+const machineView = (stepId: string) => ({
+	snapshot: { currentStepId: stepId, data: { value: 1 } } as never,
+	currentStep: { id: stepId } as never,
+	getStepStatus: () => "active" as const,
+});
+
+const ev = (over: Partial<TransitionEvent<D>> = {}): TransitionEvent<D> => ({
+	type: "next",
+	fromStepId: "a",
+	toStepId: "b",
+	data: { value: 1 },
+	timestamp: 0,
+	...over,
+});
+
+// controllable clock
+const makeClock = () => {
+	let t = 1000;
+	return {
+		now: () => t,
+		advance: (ms: number) => {
+			t += ms;
+		},
+	};
+};
+
+describe("createAnalyticsPlugin", () => {
+	it("has the fixed plugin name 'analytics'", () => {
+		expect(createAnalyticsPlugin().name).toBe("analytics");
+	});
+
+	it("measures step time correctly across an afterTransition", () => {
+		const clock = makeClock();
+		const onStepComplete = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onStepComplete });
+		plugin.onInit?.(machineView("a"));
+		clock.advance(500);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		expect(onStepComplete).toHaveBeenCalledWith("a", 500);
+		expect(plugin.getReport().stepTimings.a).toBe(500);
+	});
+
+	it("fires onStepView for the initial step (onInit) and each entered step (afterTransition)", () => {
+		const clock = makeClock();
+		const onStepView = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onStepView });
+		plugin.onInit?.(machineView("a"));
+		expect(onStepView).toHaveBeenCalledWith("a", { value: 1 });
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		expect(onStepView).toHaveBeenCalledWith("b", { value: 1 });
+	});
+
+	it("counts a backtrack via 'previous'", () => {
+		const clock = makeClock();
+		const onBacktrack = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onBacktrack });
+		plugin.onInit?.(machineView("a"));
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		clock.advance(100);
+		plugin.afterTransition?.(
+			ev({ type: "previous", fromStepId: "b", toStepId: "a" }),
+		);
+		expect(onBacktrack).toHaveBeenCalledWith("b", "a");
+		const report = plugin.getReport();
+		expect(report.backtrackCount).toBe(1);
+		expect(report.backtrackHistory).toHaveLength(1);
+		expect(report.backtrackHistory[0]).toMatchObject({ from: "b", to: "a" });
+		expect(report.backtrackHistory[0].at).toBe(clock.now());
+	});
+
+	it("counts a backtrack via 'goTo' to an already-viewed step, but not a forward 'goTo' to an unseen step", () => {
+		const clock = makeClock();
+		const onBacktrack = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onBacktrack });
+		plugin.onInit?.(machineView("a"));
+		// forward goTo to an unseen step "c" — not a backtrack
+		plugin.afterTransition?.(
+			ev({ type: "goTo", fromStepId: "a", toStepId: "c" }),
+		);
+		expect(onBacktrack).not.toHaveBeenCalled();
+		expect(plugin.getReport().backtrackCount).toBe(0);
+		// goTo back to "a", already viewed — is a backtrack
+		plugin.afterTransition?.(
+			ev({ type: "goTo", fromStepId: "c", toStepId: "a" }),
+		);
+		expect(onBacktrack).toHaveBeenCalledWith("c", "a");
+		expect(plugin.getReport().backtrackCount).toBe(1);
+	});
+
+	it("accumulates timing across re-entry to the same step", () => {
+		const clock = makeClock();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now });
+		plugin.onInit?.(machineView("a"));
+		clock.advance(100);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		); // a: 100
+		clock.advance(50);
+		plugin.afterTransition?.(
+			ev({ type: "previous", fromStepId: "b", toStepId: "a" }),
+		); // b: 50
+		clock.advance(200);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		); // a: +200 = 300
+		expect(plugin.getReport().stepTimings.a).toBe(300);
+		expect(plugin.getReport().stepTimings.b).toBe(50);
+	});
+
+	it("fires onWizardComplete and onStepComplete for the terminal step on completion", () => {
+		const clock = makeClock();
+		const onWizardComplete = vi.fn();
+		const onStepComplete = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({
+			now: clock.now,
+			onWizardComplete,
+			onStepComplete,
+		});
+		plugin.onInit?.(machineView("a"));
+		clock.advance(100);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		clock.advance(300);
+		plugin.onComplete?.({ value: 1 });
+		expect(onStepComplete).toHaveBeenCalledWith("a", 100);
+		expect(onStepComplete).toHaveBeenCalledWith("b", 300);
+		expect(onWizardComplete).toHaveBeenCalledWith({ value: 1 }, 400);
+		const report = plugin.getReport();
+		expect(report.completed).toBe(true);
+		expect(report.totalDuration).toBe(400);
+	});
+
+	it("fires onDropOff on destroy of an incomplete wizard", () => {
+		const clock = makeClock();
+		const onDropOff = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onDropOff });
+		plugin.onInit?.(machineView("a"));
+		clock.advance(250);
+		plugin.destroy?.();
+		expect(onDropOff).toHaveBeenCalledWith("a", 250);
+	});
+
+	it("does NOT fire onDropOff on destroy after completion", () => {
+		const clock = makeClock();
+		const onDropOff = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onDropOff });
+		plugin.onInit?.(machineView("a"));
+		plugin.onComplete?.({ value: 1 });
+		clock.advance(1000);
+		plugin.destroy?.();
+		expect(onDropOff).not.toHaveBeenCalled();
+	});
+
+	it("getReport folds in the live open-visit duration and reports a live totalDuration", () => {
+		const clock = makeClock();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now });
+		plugin.onInit?.(machineView("a"));
+		clock.advance(150);
+		const report = plugin.getReport();
+		expect(report.stepTimings.a).toBe(150);
+		expect(report.totalDuration).toBe(150);
+		expect(report.currentStep).toBe("a");
+		expect(report.completed).toBe(false);
+	});
+
+	it("resets counters, timings, and completed state on onReset, restoring the initial step timer", () => {
+		const clock = makeClock();
+		const onDropOff = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onDropOff });
+		plugin.onInit?.(machineView("a"));
+		clock.advance(100);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		clock.advance(50);
+		plugin.afterTransition?.(
+			ev({ type: "previous", fromStepId: "b", toStepId: "a" }),
+		);
+		plugin.onComplete?.({ value: 1 });
+
+		clock.advance(10);
+		plugin.onReset?.();
+		const report = plugin.getReport();
+		expect(report.backtrackCount).toBe(0);
+		expect(report.backtrackHistory).toEqual([]);
+		// stepTimings folds in the freshly-reopened step's live visit (0ms elapsed so far)
+		expect(report.stepTimings).toEqual({ a: 0 });
+		expect(report.completed).toBe(false);
+		expect(report.currentStep).toBe("a");
+		expect(report.startedAt).toBe(clock.now());
+
+		// a subsequent destroy fires onDropOff again for the fresh session
+		clock.advance(75);
+		plugin.destroy?.();
+		expect(onDropOff).toHaveBeenCalledWith("a", 75);
+	});
+
+	it("is robust to a throwing user callback — internal state stays consistent", () => {
+		const clock = makeClock();
+		const plugin = createAnalyticsPlugin<D>({
+			now: clock.now,
+			onStepComplete: () => {
+				throw new Error("boom");
+			},
+		});
+		plugin.onInit?.(machineView("a"));
+		clock.advance(100);
+		expect(() =>
+			plugin.afterTransition?.(
+				ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+			),
+		).toThrow("boom");
+		// state was mutated BEFORE the throwing callback ran
+		const report = plugin.getReport();
+		expect(report.stepTimings.a).toBe(100);
+		expect(report.currentStep).toBe("b");
+	});
+
+	it("uses a default clock (Date.now) producing non-negative durations", () => {
+		const plugin = createAnalyticsPlugin<D>();
+		plugin.onInit?.(machineView("a"));
+		const report = plugin.getReport();
+		expect(report.totalDuration).toBeGreaterThanOrEqual(0);
+	});
+});

--- a/packages/core/tests/analytics-plugin.test.ts
+++ b/packages/core/tests/analytics-plugin.test.ts
@@ -237,4 +237,84 @@ describe("createAnalyticsPlugin", () => {
 		const report = plugin.getReport();
 		expect(report.totalDuration).toBeGreaterThanOrEqual(0);
 	});
+
+	it("onInit is idempotent: a second onInit fully clears timings/backtracks/viewedSteps", () => {
+		const clock = makeClock();
+		const onBacktrack = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({ now: clock.now, onBacktrack });
+
+		// ── first (discarded probe) session: init at "a", walk a->b->a ──
+		plugin.onInit?.(machineView("a"));
+		clock.advance(100);
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+		clock.advance(50);
+		plugin.afterTransition?.(
+			ev({ type: "previous", fromStepId: "b", toStepId: "a" }),
+		);
+		expect(plugin.getReport().backtrackCount).toBe(1);
+		plugin.destroy?.(); // StrictMode discards the probe
+
+		// ── second (real) session on the SAME instance: re-init at "a" ──
+		onBacktrack.mockClear();
+		plugin.onInit?.(machineView("a"));
+		const report = plugin.getReport();
+		// fully re-seeded: no residue from the probe session
+		expect(report.backtrackCount).toBe(0);
+		expect(report.backtrackHistory).toEqual([]);
+		expect(report.stepTimings).toEqual({ a: 0 }); // only the freshly reopened live visit
+		expect(report.currentStep).toBe("a");
+		expect(report.completed).toBe(false);
+
+		// a forward goTo to a step that was viewed ONLY in the probe session must NOT
+		// be misclassified as a backtrack (proves viewedSteps was cleared):
+		plugin.afterTransition?.(
+			ev({ type: "goTo", fromStepId: "a", toStepId: "b" }),
+		);
+		expect(onBacktrack).not.toHaveBeenCalled();
+		expect(plugin.getReport().backtrackCount).toBe(0);
+	});
+
+	it("absorbs an in-flight afterTransition when added mid-transition (no double view / phantom complete)", () => {
+		const clock = makeClock();
+		const onStepView = vi.fn();
+		const onStepComplete = vi.fn();
+		const onBacktrack = vi.fn();
+		const plugin = createAnalyticsPlugin<D>({
+			now: clock.now,
+			onStepView,
+			onStepComplete,
+			onBacktrack,
+		});
+
+		// use() ran mid-transition: state already committed to "b", so onInit seeds "b".
+		plugin.onInit?.(machineView("b"));
+		expect(onStepView).toHaveBeenCalledTimes(1);
+		expect(onStepView).toHaveBeenCalledWith("b", { value: 1 });
+
+		clock.advance(30);
+		// the in-flight transition's afterTransition finally arrives: a -> b.
+		plugin.afterTransition?.(
+			ev({ type: "next", fromStepId: "a", toStepId: "b" }),
+		);
+
+		// absorbed: NO second onStepView("b"), NO phantom onStepComplete, NO backtrack.
+		expect(onStepView).toHaveBeenCalledTimes(1);
+		expect(onStepComplete).not.toHaveBeenCalled();
+		expect(onBacktrack).not.toHaveBeenCalled();
+
+		// "a" is now recorded as previously visited, so a later goTo back to "a" is a backtrack,
+		// and "b"'s live timer keeps running from onInit (not reset by the absorbed event).
+		const report = plugin.getReport();
+		expect(report.currentStep).toBe("b");
+		expect(report.stepTimings.b).toBe(30); // continuous since onInit, no bogus close
+
+		clock.advance(10);
+		plugin.afterTransition?.(
+			ev({ type: "goTo", fromStepId: "b", toStepId: "a" }),
+		);
+		expect(onBacktrack).toHaveBeenCalledWith("b", "a"); // "a" was marked viewed by the absorb
+		expect(plugin.getReport().backtrackCount).toBe(1);
+	});
 });

--- a/packages/core/tests/plugins-barrel.test.ts
+++ b/packages/core/tests/plugins-barrel.test.ts
@@ -4,12 +4,19 @@ describe("plugin barrels", () => {
 	it("exposes plugin public API from the subpath barrel (src)", async () => {
 		const mod = await import("../src/plugins/index");
 		expect(typeof mod.createLoggingPlugin).toBe("function");
+		expect(typeof mod.createAnalyticsPlugin).toBe("function");
 		expect((mod as Record<string, unknown>).PluginHost).toBeUndefined();
 	});
 
 	it("re-exports createLoggingPlugin from the main barrel", async () => {
 		const mod = await import("../src/index");
 		expect(typeof mod.createLoggingPlugin).toBe("function");
+		expect((mod as Record<string, unknown>).PluginHost).toBeUndefined();
+	});
+
+	it("re-exports createAnalyticsPlugin from the main barrel", async () => {
+		const mod = await import("../src/index");
+		expect(typeof mod.createAnalyticsPlugin).toBe("function");
 		expect((mod as Record<string, unknown>).PluginHost).toBeUndefined();
 	});
 });

--- a/packages/docs/guide/api/core.md
+++ b/packages/docs/guide/api/core.md
@@ -1026,3 +1026,57 @@ function createLoggingPlugin<TData>(config?: {
   logger?: Pick<Console, "log" | "warn" | "debug">; // default: console
 }): WizardPlugin<TData>;
 ```
+
+### `createAnalyticsPlugin`
+
+Built-in analytics collector. Auto-times each step, counts backtracks, records drop-off
+on teardown, and fires optional callbacks. The returned instance adds a synchronous
+`getReport()` method. Never vetoes. Timing uses `config.now` (default `Date.now`), not
+`TransitionEvent.timestamp`, so durations are injectable in tests.
+
+```ts
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+// or: import { createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
+
+function createAnalyticsPlugin<TData>(
+  config?: AnalyticsPluginConfig<TData>,
+): AnalyticsPlugin<TData>;
+
+interface AnalyticsPluginConfig<TData> {
+  onStepView?(stepId: StepId, data: DeepReadonly<TData>): void;
+  onStepComplete?(stepId: StepId, durationMs: number): void;
+  onWizardComplete?(data: DeepReadonly<TData>, totalDurationMs: number): void;
+  /** Fired on destroy() only if the wizard was not completed. */
+  onDropOff?(stepId: StepId, durationMs: number): void;
+  onBacktrack?(fromStepId: StepId, toStepId: StepId): void;
+  /** Injectable clock for testability. Defaults to Date.now. */
+  now?: () => number;
+}
+
+type AnalyticsPlugin<TData> = WizardPlugin<TData> & {
+  getReport(): AnalyticsReport;
+};
+
+interface AnalyticsReport {
+  startedAt: number;
+  stepTimings: Record<StepId, number>; // includes the current step's live open visit
+  backtrackCount: number;
+  backtrackHistory: BacktrackEntry[];
+  currentStep: StepId | null;
+  completed: boolean;
+  totalDuration: number;
+}
+
+interface BacktrackEntry {
+  from: StepId;
+  to: StepId;
+  at: number;
+}
+```
+
+A step's timer closes on `afterTransition` (or in `onComplete` for the terminal step);
+`getReport()` folds the current step's still-open visit into `stepTimings` and
+`totalDuration`. A backtrack is any `previous` transition, or a `goTo` to a
+previously-visited step. `onDropOff` fires from `destroy()` only when the wizard never
+completed. Resetting the wizard restarts the analytics session in place and does not
+re-emit `onStepView`.

--- a/packages/docs/guide/plugins.md
+++ b/packages/docs/guide/plugins.md
@@ -214,21 +214,25 @@ While any navigation (`goNext`, `goPrevious`, `goTo`) is in progress, the machin
 
 ## Import Paths
 
-All plugin types and `createLoggingPlugin` are available from both the main barrel and a dedicated subpath:
+All plugin types, `createLoggingPlugin`, and `createAnalyticsPlugin` are available from both the main barrel and a dedicated subpath:
 
 ```ts
 // Main barrel — works for most cases:
-import { createLoggingPlugin } from "@gooonzick/wizard-core";
+import { createLoggingPlugin, createAnalyticsPlugin } from "@gooonzick/wizard-core";
 import type { WizardPlugin, TransitionEvent, ErrorContext } from "@gooonzick/wizard-core";
 
 // Dedicated subpath — useful for tree-shaking or plugin-only bundles:
-import { createLoggingPlugin } from "@gooonzick/wizard-core/plugins";
+import { createLoggingPlugin, createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
 import type {
   WizardPlugin,
   TransitionEvent,
   ErrorContext,
   WizardMachineReadonly,
   DeepReadonly,
+  AnalyticsReport,
+  BacktrackEntry,
+  AnalyticsPluginConfig,
+  AnalyticsPlugin,
 } from "@gooonzick/wizard-core/plugins";
 ```
 
@@ -267,22 +271,130 @@ function MyWizard() {
 
 ---
 
+## Built-in Plugin: `createAnalyticsPlugin`
+
+The analytics plugin is a second built-in. It automatically times each step, counts
+backward navigations ("backtracks"), records drop-off on teardown, and fires optional
+callbacks. Unlike `createLoggingPlugin`, the returned instance exposes a synchronous
+`getReport()` method for reading aggregated metrics at any time. It never vetoes.
+
+```ts
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+// or: import { createAnalyticsPlugin } from "@gooonzick/wizard-core/plugins";
+
+const analytics = createAnalyticsPlugin<SignupData>({
+  onStepView: (stepId, data) => track("step_view", { stepId }),
+  onStepComplete: (stepId, durationMs) => track("step_complete", { stepId, durationMs }),
+  onBacktrack: (from, to) => track("backtrack", { from, to }),
+  onWizardComplete: (data, totalDurationMs) => track("wizard_complete", { totalDurationMs }),
+  onDropOff: (stepId, durationMs) => track("drop_off", { stepId, durationMs }),
+  // now: () => Date.now(), // injectable clock; defaults to Date.now
+});
+
+machine.use(analytics);
+
+// Read aggregates at any time — includes the current step's live open-visit time:
+const report = analytics.getReport();
+```
+
+### Config
+
+All callbacks are optional; pass only what you need.
+
+| Option | Signature | When it fires |
+|---|---|---|
+| `onStepView` | `(stepId, data) => void` | On init and on every step entered (including backtracks). |
+| `onStepComplete` | `(stepId, durationMs) => void` | When a step is **left** — on each transition for the departing step, and on completion for the terminal step. |
+| `onBacktrack` | `(fromStepId, toStepId) => void` | On a `previous` transition, or a `goTo` targeting an already-viewed step. |
+| `onWizardComplete` | `(data, totalDurationMs) => void` | When the wizard completes. |
+| `onDropOff` | `(stepId, durationMs) => void` | On teardown (`destroy`) **only if the wizard never completed**. |
+| `now` | `() => number` | Injectable clock used for all timing. Defaults to `Date.now`. |
+
+### `getReport()`
+
+`analytics.getReport()` returns a snapshot of type `AnalyticsReport`:
+
+```ts
+interface AnalyticsReport {
+  startedAt: number;                       // now() at session start (onInit / first hook / last reset)
+  stepTimings: Record<StepId, number>;     // accumulated ms per step, INCLUDING the current live visit
+  backtrackCount: number;                  // number of backward navigations this session
+  backtrackHistory: BacktrackEntry[];      // ordered list of { from, to, at }
+  currentStep: StepId | null;              // most recently entered step, or null before any step
+  completed: boolean;                      // true once onWizardComplete fired (reset clears it)
+  totalDuration: number;                   // completed ? completedAt - startedAt : now() - startedAt
+}
+
+interface BacktrackEntry {
+  from: StepId;
+  to: StepId;
+  at: number;
+}
+```
+
+### Semantics
+
+- **Step timers.** Each step's open visit accumulates elapsed time. A step's timer
+  closes on `afterTransition` (when you leave it); the final step's timer closes in
+  `onComplete`. `getReport()` folds the current step's still-open visit into
+  `stepTimings` and into `totalDuration`, so metrics are always live.
+- **Backtracks.** A backtrack is any `previous` transition, or a `goTo` to a step you
+  have already visited this session.
+- **Drop-off.** `onDropOff` fires from `destroy()` **only if** the wizard was never
+  completed — completed wizards never drop off. In React/Vue this happens automatically
+  on unmount.
+- **Injectable clock.** All durations use `config.now` (default `Date.now`), not the
+  transition `timestamp`, so tests can inject a deterministic clock.
+- **Throw-safe.** The plugin updates its internal bookkeeping *before* invoking your
+  callbacks, so a throwing callback can never corrupt the report.
+- **Reset.** Resetting the wizard restarts the analytics session in place (timings,
+  backtracks, and `completed` are cleared and the initial step's timer restarts). Reset
+  does **not** re-emit `onStepView`.
+
+**React example:**
+
+```tsx
+import { useMemo } from "react";
+import { createAnalyticsPlugin } from "@gooonzick/wizard-core";
+
+function MyWizard() {
+  const analytics = useMemo(
+    () => createAnalyticsPlugin<MyData>({
+      onStepComplete: (stepId, ms) => console.log(stepId, "took", ms, "ms"),
+    }),
+    [],
+  );
+  const plugins = useMemo(() => [analytics], [analytics]);
+
+  const { state } = useWizard({ definition, initialData, plugins });
+
+  // Read live aggregates whenever you need them:
+  const onShowReport = () => console.log(analytics.getReport());
+  // ...
+}
+```
+
+---
+
 ## Writing Your Own Plugin
 
-A plugin is a plain object with a `name` and any subset of the optional hooks. Here is a minimal analytics plugin:
+A plugin is a plain object with a `name` and any subset of the optional hooks. (For
+built-in analytics use `createAnalyticsPlugin` above; the example below shows how you
+would build a custom tracking plugin from scratch.) Here is a minimal tracking
+plugin:
 
 ```ts
 import type { WizardPlugin, TransitionEvent, DeepReadonly } from "@gooonzick/wizard-core";
 
-interface AnalyticsConfig {
+interface TrackingConfig {
   track: (event: string, props?: Record<string, unknown>) => void;
 }
 
-function createAnalyticsPlugin<TData>(
-  config: AnalyticsConfig,
+function createTrackingPlugin<TData>(
+  config: TrackingConfig,
 ): WizardPlugin<TData> {
   return {
-    name: "analytics",
+    name: "tracking",
 
     onInit(machine) {
       config.track("wizard_init", {
@@ -321,7 +433,7 @@ function createAnalyticsPlugin<TData>(
 
 ```ts
 const machine = new WizardMachine(definition, context, initialData, events, [
-  createAnalyticsPlugin({ track: myAnalyticsLib.track }),
+  createTrackingPlugin({ track: myAnalyticsLib.track }),
   createLoggingPlugin({ level: "warn" }),
 ]);
 ```
@@ -330,7 +442,7 @@ Or with React:
 
 ```tsx
 const plugins = useMemo(
-  () => [createAnalyticsPlugin({ track: myAnalyticsLib.track })],
+  () => [createTrackingPlugin({ track: myAnalyticsLib.track })],
   [],
 );
 


### PR DESCRIPTION
## Summary

Ships **WIZ-016 — Analytics Helpers**: a built-in `createAnalyticsPlugin` for `@gooonzick/wizard-core`, exported from the main barrel and the `/plugins` subpath alongside `createLoggingPlugin`.

- **Callbacks:** `onStepView`, `onStepComplete(stepId, durationMs)`, `onWizardComplete(data, totalDurationMs)`, `onDropOff` (fired on `destroy()` only if the wizard never completed), `onBacktrack(from, to)`
- **`getReport()`** returns `{ startedAt, stepTimings, backtrackCount, backtrackHistory, currentStep, completed, totalDuration }`, folding in the current step's live open-visit time
- **Semantics** (reconciled with the shipped WIZ-007 plugin API): step timer closes on `afterTransition` (the only committed-success signal; `beforeTransition` fires on vetoed transitions too), terminal step closes in `onComplete`; backtrack = `previous` transition or `goTo` to an already-viewed step; injectable `now?: () => number` clock for testability; bookkeeping runs before user callbacks so a throwing callback can't corrupt the report
- **Docs:** new sections in `plugins.md` + `api/core.md` (both the `docs/` mirror and the VitePress guide), api-reference updates, ROADMAP marked ✅ Done with shipped-vs-specced deltas; the DIY example plugin that collided with the new name is renamed to `createTrackingPlugin`; wizard-library agent skill references extended
- **Examples:** analytics demo per framework (React + Vue) with a live `getReport()` panel and event feed
- **Changeset:** `minor` for `@gooonzick/wizard-core`; the `fixed` group in `.changeset/config.json` bumps `core`/`react`/`vue`/`state` to one shared version

## Test plan

- [x] 15 new tests (13 direct-hook unit + 2 integration against a real `WizardMachine`), core suite: 296 passed
- [x] `pnpm lint` (6/6), `pnpm typecheck` (14/14), `pnpm build` (7/7), `pnpm test` (all packages) — green
- [x] `pnpm docs:build` — green, new content picked up
- [x] Example apps: `tsc --noEmit` / `vue-tsc --build` + biome/oxlint/eslint — green